### PR TITLE
Handle shorter WM_HINTS

### DIFF
--- a/manager.lisp
+++ b/manager.lisp
@@ -151,7 +151,7 @@
   wm-hints)
 
 (defun decode-wm-hints (vector display)
-  (declare (type (simple-vector 9) vector)
+  (declare (type (simple-vector *) vector)
 	   (type display display))
   (declare (clx-values wm-hints))
   (let ((input-hint 0)


### PR DESCRIPTION
The hints vector can have length shorter than 9.
See http://tronche.com/gui/x/xlib/ICC/client-to-window-manager/wm-hints.html

This fixes a stumpwm crash when running nvlc or cvlc.
