### PR TITLE
Fix X11 socket discovery on recent versions of XQuartz/OS X

### DIFF
--- a/depdefs.lisp
+++ b/depdefs.lisp
@@ -689,6 +689,7 @@ nil if a network socket should be opened."
   (cond ((or (string= host "") (string= host "unix"))
 	 (format nil "~A~D" +X-unix-socket-path+ display))
 	#+darwin
-	((and (> (length host) 10) (string= host "tmp/launch" :end1 10))
+	((or (and (> (length host) 10) (string= host "tmp/launch" :end1 10))
+	     (and (> (length host) 29) (string= host "private/tmp/com.apple.launchd" :end1 29)))
 	 (format nil "/~A:~D" host display))	  
 	(t nil)))

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -1545,16 +1545,17 @@
 (defun open-x-stream (host display protocol)  
   (declare (ignore protocol)
            (type (integer 0) display))
-  (socket-make-stream 
-   (if (or (string= host "") (string= host "unix")) ; AF_LOCAL domain socket
-       (let ((s (make-instance 'local-socket :type :stream)))
-	 (socket-connect s (format nil "~A~D" +X-unix-socket-path+ display))
-	 s)
-       (let ((host (car (host-ent-addresses (get-host-by-name host)))))
-	 (when host
-	   (let ((s (make-instance 'inet-socket :type :stream :protocol :tcp)))
-	     (socket-connect s host (+ 6000 display))
-	     s))))
+  (socket-make-stream
+   (let ((unix-domain-socket-path (unix-socket-path-from-host host display)))
+     (if unix-domain-socket-path
+         (let ((s (make-instance 'local-socket :type :stream)))
+           (socket-connect s unix-domain-socket-path)
+           s)
+         (let ((host (car (host-ent-addresses (get-host-by-name host)))))
+           (when host
+             (let ((s (make-instance 'inet-socket :type :stream :protocol :tcp)))
+               (socket-connect s host (+ 6000 display))
+               s)))))
    :element-type '(unsigned-byte 8)
    :input t :output t :buffering :none))
 


### PR DESCRIPTION
On my OS X machine, CLX refused to work with the local X11 socket, trying to resolve the file name as a host name instead and failing.  I found that there were some hardwired paths in CLX that needed updating.  That's what this pull request does, at least for SBCL and Clozure CL (I haven't tested anything else).