### PR TITLE
get-best-authorization handle xauth with null display

### DIFF
--- a/display.lisp
+++ b/display.lisp
@@ -116,7 +116,7 @@
 	       (unless family (return))
 	       (when (and (eql family protocol)
 			  (equal host-address address)
-			  (= number display)
+			  (or (null number) (= number display))
 			  (let ((pos1 (position name *known-authorizations*
 						:test #'string=)))
 			    (and pos1


### PR DESCRIPTION
Hey,

When the xauth file contains an entry that has a null display value, get-best-authorization fails. The error is described in stumpwm/stumpwm#239 I have applied the fix as described in the bug report and it works great.

Below is the stacktrace and the result of manually parsing the xauth file.  Not sure why the value is null, but this seems to work.  I'm using Debian sid.

```
DISPLAY=:1.0 ./stumpwm

debugger invoked on a SIMPLE-TYPE-ERROR in thread
#<THREAD "main thread" RUNNING {1005984973}>:
  Argument X is not a NUMBER: NIL

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

(no restarts: If you didn't do this on purpose, please report it as a bug.)

(SB-KERNEL:TWO-ARG-= NIL 1)
0] backtrace

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1005984973}>
0: (SB-KERNEL:TWO-ARG-= NIL 1)
1: (SB-VM::GENERIC-=)
2: (XLIB::GET-BEST-AUTHORIZATION "" 1 :LOCAL)
3: (XLIB:OPEN-DISPLAY "" :DISPLAY 1 :PROTOCOL :LOCAL :AUTHORIZATION-NAME NIL :AUTHORIZATION-DATA NIL)
4: (STUMPWM::STUMPWM-INTERNAL ":1.0")
5: (STUMPWM:STUMPWM ":1.0")
6: ((LAMBDA NIL :IN "/home/russell/projects/lisp/stumpwm/make-image.lisp"))
7: ((FLET #:WITHOUT-INTERRUPTS-BODY-82 :IN SAVE-LISP-AND-DIE))
8: ((LABELS SB-IMPL::RESTART-LISP :IN SAVE-LISP-AND-DIE))

0] d  
(SB-VM::GENERIC-=)
1] d
(XLIB::GET-BEST-AUTHORIZATION "" 1 :LOCAL)
2] l
XLIB::BEST-DATA  =  NIL
XLIB::BEST-NAME  =  NIL
XLIB::BEST-POS  =  NIL
XLIB:DISPLAY  =  1
#:G167  =  T
#:G179  =  NIL
XLIB::HOST  =  ""
XLIB::HOST-ADDRESS  =  "sparky"
PATHNAME  =  #P"/run/user/1000/gdm/Xauthority"
XLIB::PROTOCOL  =  :LOCAL
STREAM  =  #<SB-SYS:FD-STREAM for "file /run/user/1000/gdm/Xauthority" {1005AC6E93}>
```

```
CL-USER> (with-open-file (stream "/run/user/1000/gdm/Xauthority"  :element-type '(unsigned-byte 8)
			      :if-does-not-exist nil) (xlib::read-xauth-entry stream))
(:LOCAL "sparky" NIL "MIT-MAGIC-COOKIE-1"
 #(251 255 76 176 22 150 6 190 130 221 70 46 199 176 73 203))
```