### PR TITLE
fixed randr compile problems, quick fix

### DIFF
--- a/extensions/big-requests.lisp
+++ b/extensions/big-requests.lisp
@@ -1,0 +1,31 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;;
+;;; (c) copyright 2006 Richard Kreuter
+;;; (c) copyright 2007 by Christophe Rhodes
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+(in-package "XLIB")
+
+;;; No new events or errors are defined by this extension.  (Big
+;;; Requests Extension, section 3)
+;;;
+;;; The name of this extension is "BIG-REQUESTS" (Big Requests
+;;; Extension, section 4)
+(define-extension "BIG-REQUESTS")
+
+(defun enable-big-requests (display)
+  (declare (type display display))
+  (let ((opcode (extension-opcode display "BIG-REQUESTS")))
+    (with-buffer-request-and-reply (display opcode nil)
+	((data 0))
+      (let ((maximum-request-length (card32-get 8)))
+	(setf (display-extended-max-request-length display) 
+	      maximum-request-length)))))

--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -1,0 +1,159 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: Composite Extension
+;;;   Created: 2014-11-17
+;;;    Author: Johannes Martinez <johannes.martinez@gmail.com>
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2014 by Johannes Martinez
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+(in-package :xlib)
+
+(export '(composite-query-version
+	  composite-redirect-window
+	  composite-redirect-subwindows
+	  composite-unredirect-window
+	  composite-unredirect-subwindows
+	  composite-get-overlay-window
+	  
+	  ))
+(define-extension "Composite")
+
+(defconstant +composite-major+    0)
+(defconstant +composite-minor+    4)
+
+
+(defconstant +redirect-automatic+		0)
+(defconstant +redirect-manual+			1)
+
+;; xrequests
+
+(defconstant  +composite-QueryVersion+			0)
+(defconstant  +composite-RedirectWindow+		1)
+(defconstant  +composite-RedirectSubwindows+		2)
+(defconstant  +composite-UnredirectWindow+		3)
+(defconstant  +composite-UnredirectSubwindows+		4)
+(defconstant  +composite-CreateRegionFromBorderClip+	5)
+(defconstant  +composite-NameWindowPixmap+		6)
+(defconstant  +composite-GetOverlayWindow+             7)
+(defconstant  +composite-ReleaseOverlayWindow+         8)
+
+
+(defmacro composite-opcode (display)
+  `(extension-opcode ,display "Composite"))
+
+;; types
+
+(deftype update-type () '(card8))
+
+
+
+;; x requests
+
+(defun composite-query-version (display)
+  ""
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (composite-opcode display) nil :sizes (32))
+				 ((data +composite-QueryVersion+)
+				  (card32 +composite-major+)
+				  (card32 +composite-minor+))
+    (values
+     (card32-get 8)
+     (card32-get 12))))
+
+
+
+(defun composite-redirect-window (window update-type)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window)
+	     (type update-type update-type))  
+    (with-buffer-request (display (composite-opcode display))
+      (data +composite-redirectwindow+)
+      (window window)
+      (card8 update-type)
+      (card8 0)
+      (card16 0))))
+
+(defun composite-redirect-subwindows (window update-type)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window)
+	     (type update-type update-type))  
+    (with-buffer-request (display (composite-opcode display))
+      (data +composite-redirectsubwindows+)
+      (window window)
+      (card8 update-type)
+      (card8 0)
+      (card16 0))))
+
+(defun composite-unredirect-window (window)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))  
+    (with-buffer-request (display (composite-opcode display))
+      (data +composite-unredirectwindow+)
+      (window window))))
+
+(defun composite-unredirect-subwindows (window)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))  
+    (with-buffer-request (display (composite-opcode display))
+      (data +composite-unredirectsubwindows+)
+      (window window))))
+
+(defun composite-create-region-from-border-clip (window region)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))
+    (with-buffer-request (display (composite-opcode display)) 
+      (data +composite-createregionfromborderclip+)
+      (card32 region)
+      (window window))))
+	    
+(defun composite-name-window-pixmap (window drawable)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))
+    (with-buffer-request (display (composite-opcode display))
+      ((data +composite-namewindowpixmap+)
+       (window window)
+       (drawable drawable)))))
+
+(defun composite-get-overlay-window (window)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))
+    (with-buffer-request-and-reply (display (composite-opcode display) nil :sizes (32))
+				   ((data +composite-getoverlaywindow+)
+				    (window window)
+				    )
+      (values
+       (card32-get 8)))))
+
+(defun composite-release-overlay-window (window)
+  ""
+  (let ((display (window-display window))))
+  (declare (type display display)
+	   (type window window))
+  (with-buffer-request (display (composite-opcode display))
+				 ((data +composite-releaseoverlaywindow+)
+				  (window window))))

--- a/extensions/dbe.lisp
+++ b/extensions/dbe.lisp
@@ -1,0 +1,202 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: Double Buffer Extension
+;;;   Created: 2014-11-17
+;;;    Author: Johannes Martinez <johannes.martinez@gmail.com>
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2014 by Johannes Martinez
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+(in-package :xlib)
+
+(export '(;;  x requests
+	  dbe-query-version
+	  dbe-get-visual-info
+	  dbe-allocate-back-buffer-name
+	  dbe-deallocate-back-buffer-name
+	  dbe-swap-buffers
+	  dbe-begin-idiom
+	  dbe-end-idiom
+	  dbe-get-back-buffer-attributes
+	  ;; convenience function
+	  create-back-buffer
+	  ;; swap-hint constants
+	  +undefined+
+	  +background+
+	  +untouched+
+	  +copied+)
+	:xlib)
+
+(define-extension "DOUBLE-BUFFER"
+  :errors (dbe-bad-buffer))
+
+;; version
+
+(defconstant +major+                        1)
+(defconstant +minor+                        0)
+
+;; request codes
+
+(defconstant +query-version+                0)
+(defconstant +allocate-back-buffer-name+    1)
+(defconstant +deallocate-back-buffer-name+  2)
+(defconstant +swap-buffers+                 3)
+(defconstant +begin-idiom+                  4)
+(defconstant +end-idiom+                    5)
+(defconstant +get-visual-info+              6)
+(defconstant +get-back-buffer-attributes+   7)
+
+;; swap actions
+
+(defconstant +undefined+  #x00)
+(defconstant +background+ #x01)
+(defconstant +untouched+  #x02)
+(defconstant +copied+     #x03)
+
+;; Errors ??
+
+(define-condition dbe-bad-buffer (request-error) ())
+(define-error dbe-bad-buffer decode-core-error)
+
+;; class and structure definitions
+
+;; use def-clx-class instead of deftype to be consistent with clx and be able to submit
+;; back-buffers to other x-requests that accept drawables, for convenience should probably just
+;; have get-visual-info return visual-ids or visual-info structs
+
+(def-clx-class (back-buffer (:include drawable) (:copier nil)
+			    (:print-function print-drawable)))
+
+(defstruct visinfo 
+  (visual-id 0 :type (unsigned-byte 32))
+  (depth 0 :type (unsigned-byte 8))
+  (perflevel 0 :type (unsigned-byte 8))
+  (unused 0 :type (unsigned-byte 16)))
+
+;; convenience function
+
+(defun create-back-buffer (window)
+  "Returns a back-buffer structure associated with the given window"
+  
+  (let* ((display (window-display window))
+	 (bb (make-back-buffer :display display))
+	 (id (allocate-resource-id display bb 'back-buffer)))
+    (declare (type display display)
+	     (type window window)
+	     (type drawable bb))
+    (setf (back-buffer-id bb) id)
+    (if (window-p window)
+	(dbe-allocate-back-buffer-name window bb))
+    bb))
+
+;; X requests
+
+(defun dbe-query-version (display)
+  "Returns Major and Minor versions as values"
+  (declare (display display))
+  (with-buffer-request-and-reply (display (extension-opcode display "DOUBLE-BUFFER") nil)
+				   ((data +query-version+)
+				    (card8 +major+)
+				    (card8 +minor+))
+      (values
+       (card8-get 8)
+       (card8-get 9))))
+
+(defun dbe-allocate-back-buffer-name (window back-buffer &optional (swap-hint +copied+))
+  "Associates the given back-buffer with given window, optional swap-hint "
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window)
+	     (type back-buffer back-buffer)
+	     (type card8 swap-hint))
+    (with-buffer-request (display (extension-opcode display "DOUBLE-BUFFER")) 
+      (data +allocate-back-buffer-name+)
+      (window window)
+      (drawable back-buffer)
+      (card8 swap-hint)
+      (pad8)                                  ;unused
+      (pad16))))				 ;unused
+
+(defun dbe-deallocate-back-buffer-name (back-buffer)
+  "disconnects back-buffer from window, does not free xid from the server allowing buffer to be associated with another window"
+  (let ((display (back-buffer-display back-buffer)))
+    (declare (type display display)
+	     (type back-buffer back-buffer))
+    (with-buffer-request (display (extension-opcode display "DOUBLE-BUFFER"))
+      (data +deallocate-back-buffer-name+)
+      (drawable back-buffer))))
+
+(defun dbe-swap-buffers  (window-list)
+  "takes a list of (window swap-action) pairs and swaps their back-buffers"
+  (let ((display (window-display (caar window-list)))
+	 (num (length window-list))
+	 (seq (lst->array window-list)))
+    (declare (type display display)
+	     (type fixnum num)
+	     (type simple-array seq))
+       (with-buffer-request (display (extension-opcode display "DOUBLE-BUFFER"))
+	 (data +swap-buffers+)
+	 (card32 num)
+	 ((sequence :format card32) seq))))
+
+(defun dbe-begin-idiom (display)
+  (with-buffer-request (display (extension-opcode display "DOUBLE-BUFFER"))
+    (data +begin-idiom+)))
+
+(defun dbe-end-idiom (display)
+  (with-buffer-request (display (extension-opcode display "DOUBLE-BUFFER"))
+    (data +end-idiom+)))
+
+(defun dbe-get-visual-info (drawable-list)
+  "Not very useful in this modern graphics age, nothing added or taken away from the bare x." 
+  (let ((display (drawable-display (car drawable-list))) 
+	(num (length drawable-list))
+	(wl (map 'vector #'drawable-id drawable-list)))
+    (declare (type display display)
+	     (type fixnum num))
+    (with-buffer-request-and-reply (display (extension-opcode display "DOUBLE-BUFFER") nil :sizes (8 16 32))
+				   ((data +get-visual-info+)
+				    (card32 num)
+				    ((sequence :format card32) wl))
+      (values (let ((num (card32-get 8))
+      		    (next  32)
+      		    (result-list ()))
+      		(declare (type fixnum num next))
+      		(dotimes (i num (nreverse result-list))
+      		  (push 
+      		   (loop :for i :from 1 :to (card32-get next)  
+      			 :for off := (+ next 4) :then (+ off 8)
+      			 :collect (make-visinfo :visual-id (card32-get off)
+      						:depth (card8-get (+ off 4))
+      						:perflevel (card8-get (+ off 5)))
+      			 :finally (setf next (+ off 8 )))
+      		   result-list)))))))
+
+(defun dbe-get-back-buffer-attributes (back-buffer)
+  "Returns the window that a back-buffer outputs to or nil if not associated with any window"
+  (declare (type back-buffer back-buffer))
+  (let ((display (back-buffer-display back-buffer)))
+    (declare (type display display))
+    (with-buffer-request-and-reply (display (extension-opcode display "DOUBLE-BUFFER") nil :sizes 32)
+				   ((data +get-back-buffer-attributes+)
+				    (drawable back-buffer))
+      (values
+       (or-get 8 null window)))))
+
+;;  utility functions
+
+(defun lst->array (lst)
+  (make-array (* 2 (length lst)) :initial-contents 
+	      (loop :for x :in lst
+		    :collect (drawable-id (car x))
+		    :collect (cadr x))))

--- a/extensions/dpms.lisp
+++ b/extensions/dpms.lisp
@@ -1,0 +1,168 @@
+
+;;;; Original Author: Matthew Kennedy <mkennedy@gentoo.org>
+;;;;
+;;;; Documentation strings derived from DPMS.txt distributed with the Xorg X11
+;;;; server implementation.  DPMS.txt contains the following copyright:
+;;;;
+;;;;  Copyright (C) Digital Equipment Corporation, 1996
+;;;;
+;;;;  Permission to use, copy, modify, distribute, and sell this documentation
+;;;;  for any purpose is hereby granted without fee, provided that the above
+;;;;  copyright notice and this permission notice appear in all copies.  Digital
+;;;;  Equipment Corporation makes no representations about the suitability for
+;;;;  any purpose of the information in this document.  This documentation is
+;;;;  provided ``as is'' without express or implied warranty.
+
+(defpackage :dpms
+  (:use :common-lisp)
+  (:import-from :xlib
+                "DEFINE-EXTENSION"
+                "DISPLAY"
+                "WITH-BUFFER-REQUEST-AND-REPLY"
+                "WITH-BUFFER-REQUEST"
+                "EXTENSION-OPCODE"
+                "CARD8-GET"
+                "CARD16-GET"
+                "BOOLEAN-GET"
+                "CARD8"
+                "CARD16"
+                "DATA")
+  (:export "DPMS-GET-VERSION"
+           "DPMS-CAPABLE"
+           "DPMS-GET-TIMEOUTS"
+           "DPMS-SET-TIMEOUTS"
+           "DPMS-ENABLE"
+           "DPMS-DISABLE"
+           "DPMS-FORCE-LEVEL"
+           "DPMS-INFO"))
+
+(in-package :dpms)
+
+(define-extension "DPMS")
+
+(defmacro dpms-opcode (display)
+  `(extension-opcode ,display "DPMS"))
+
+(defconstant +get-version+  0)
+(defconstant +capable+      1)
+(defconstant +get-timeouts+ 2)
+(defconstant +set-timeouts+ 3)
+(defconstant +enable+       4)
+(defconstant +disable+      5)
+(defconstant +force-level+  6)
+(defconstant +info+         7)
+
+(defun dpms-get-version (display &optional (major-version 1) (minor-version 1))
+  "Return two values: the major and minor version of the DPMS
+implementation the server supports.
+
+If supplied, the MAJOR-VERSION and MINOR-VERSION indicate what
+version of the protocol the client wants the server to implement."
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (dpms-opcode display) nil)
+      ((data +get-version+)
+       (card16 major-version)
+       (card16 minor-version))
+    (values (card16-get 8)
+            (card16-get 10))))
+
+(defun dpms-capable (display)
+  "True if the currently running server's devices are capable of
+DPMS operations.  
+
+The truth value of this request is implementation defined, but is
+generally based on the capabilities of the graphic card and
+monitor combination.  Also, the return value in the case of
+heterogeneous multi-head servers is implementation defined."
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (dpms-opcode display) nil)
+      ((data +capable+))
+    (boolean-get 8)))
+
+(defun dpms-get-timeouts (display)
+  "Return three values: the current values of the DPMS timeout
+values.  The timeout values are (in order returned): standby,
+suspend and off.  All values are in units of seconds.  A value of
+zero for any timeout value indicates that the mode is disabled."
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (dpms-opcode display) nil)
+      ((data +get-timeouts+))
+    (values (card16-get 8)
+            (card16-get 10)
+            (card16-get 12))))
+
+(defun dpms-set-timeouts (display standby suspend off)
+  "Set the values of the DPMS timeouts.  All values are in units
+of seconds.  A value of zero for any timeout value disables that
+mode."
+  (declare (type display display))
+  (with-buffer-request (display (dpms-opcode display))
+    (data +set-timeouts+)
+    (card16 standby)
+    (card16 suspend)
+    (card16 off)
+    (card16 0))                         ;unused
+  (values))
+
+(defun dpms-enable (display)
+  "Enable the DPMS characteristics of the server using the
+server's currently stored timeouts.  If DPMS is already enabled,
+no change is affected."
+  (declare (type display display))
+  (with-buffer-request (display (dpms-opcode display))
+    (data +enable+))
+  (values))
+
+(defun dpms-disable (display)
+  "Disable the DPMS characteristics of the server.  It does not
+affect the core or extension screen savers.  If DPMS is already
+disabled, no change is effected.
+
+This request is provided so that DPMS may be disabled without
+damaging the server's stored timeout values."
+  (declare (type display display))
+  (with-buffer-request (display (dpms-opcode display))
+    ((data +disable+)))
+  (values))
+
+(defun dpms-force-level (display power-level)
+  "Forces a specific DPMS level on the server.  Valid keyword
+values for POWER-LEVEL are: DPMS-MODE-ON, DPMS-MODE-STANDBY,
+DPMS-MODE-SUSPEND and DPMS-MODE-OFF."
+  (declare (type display display))
+  (with-buffer-request (display (dpms-opcode display))
+    (data +force-level+)
+    (card16 (ecase power-level
+              (:dpms-mode-on 0)
+              (:dpms-mode-standby 1)
+              (:dpms-mode-suspend 2)
+              (:dpms-mode-off 3)))
+    (card16 0))                         ;unused
+  (values))
+
+(defun dpms-info (display)
+  "Returns two valus: the DPMS power-level and state value for the display.
+
+State is one of the keywords DPMS-ENABLED or DPMS-DISABLED.
+
+If state is DPMS-ENABLED, then power level is returned as one of
+the keywords DPMS-MODE-ON, DPMS-MODE-STANDBY, DPMS-MODE-SUSPEND
+or DPMS-MODE-OFF.  If state is DPMS-DISABLED, then power-level is
+undefined and returned as NIL."
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (dpms-opcode display) nil)
+      ((data +info+))
+    (let ((state (if (boolean-get 10)
+                     :dpms-enabled
+                     :dpms-disabled)))
+      (values (unless (eq state :dpms-disabled)
+                (ecase (card16-get 8)
+                  (0 :dpms-mode-on)
+                  (1 :dpms-mode-standby)
+                  (2 :dpms-mode-suspend)
+                  (3 :dpms-mode-off)))
+              state))))
+
+;;; Local Variables:
+;;; indent-tabs-mode: nil
+;;; End:

--- a/extensions/dri2.lisp
+++ b/extensions/dri2.lisp
@@ -1,0 +1,199 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: DRI Extension
+;;;   Created: 2014-11-17
+;;;    Author: Johannes Martinez <johannes.martinez@gmail.com>
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2014 by Johannes Martinez
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+(in-package :xlib)
+
+(export '(dri2-query-version
+	  dri2-authenticate
+	  dri2-connect
+	  dri2-get-buffersxo))
+
+(define-extension "DRI2")
+
+(defun dri2-opcode (display)
+  (extension-opcode display "DRI2"))
+
+;; version
+(defconstant +dri-major+			2)
+(defconstant +dri-minor+			0)
+
+;; drivers
+(defconstant DRI   0)
+(defconstant VDPAU 1)
+
+;; 0x0	DRI2BufferFrontLeft
+;; 	0x1	DRI2BufferBackLeft
+;; 	0x2	DRI2BufferFrontRight
+;; 	0x3	DRI2BufferBackRight
+;; 	0x4	DRI2BufferDepth
+;; 	0x5	DRI2BufferStencil
+;; 	0x6	DRI2BufferAccum
+;; 	0x7	DRI2BufferFakeFrontLeft
+;; 	0x8	DRI2BufferFakeFrontRight
+;; 	0x9	DRI2BufferDepthStencil
+;; 	0xa	DRI2BufferHiz
+
+;; x requests
+(defconstant +dri2-query-version+		0)
+(defconstant +dri2-connect+			1)
+(defconstant +dri2-authenticate+		2)
+(defconstant +dri2-create-drawable+		3)
+(defconstant +dri2-destroy-drawable+		4)
+(defconstant +dri2-get-buffers+		        5)
+(defconstant +dri2-copy-region+		        6)
+(defconstant +dri2-get-buffers-with-format+	7)
+(defconstant +dri2-swap-buffers+		8)
+(defconstant +dri2-get-msc+			9)
+(defconstant +dri2-wait-msc+			10)
+(defconstant +dri2-wait-sbc+			11)
+(defconstant +dri2-swap-interval+		12)
+(defconstant +dri2-get-param+			13)
+
+
+;; structs
+
+(def-clx-class (dri2-buffer (:copier nil))
+  (attachment 0 :type card32)
+  (name 0 :type card32)
+  (pitch 0 :type card32)
+  (cpp 0 :type card32)
+  (flags 0 :type card32))
+
+
+
+;; x requests
+
+(defun dri2-query-version (display)
+""
+  (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				 ((data +dri2-query-version+)
+				  (card32 +dri-major+)
+				  (card32 +dri-minor+))
+    (values
+     (card32-get 8)
+     (card32-get 12))
+))
+
+(defun dri2-connect (window driver-type)
+  ""
+  (let ((display (window-display window)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-connect+)
+				    (window window)
+				    (card32 driver-type))
+      (let* ((driver-name-length (card32-get 8))
+	    (device-name-length (card32-get 12))
+	    (device-start (+ 32 (- 4 (mod driver-name-length 4)))))
+	(values
+	 (string-get driver-name-length 32)
+	 (string-get device-name-length device-start))))))
+
+(defun dri2-authenticate (window token)
+""
+  (let ((display (window-display window)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-authenticate+)
+				    (window window)
+				    (card32 token))
+      (values
+       (card32-get 8)))))
+
+(defun dri2-create-drawable (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-create-drawable+))
+      (values))))
+(defun dri2-destroy-drawable (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ()
+      (values))))
+(defun dri2-get-buffers (drawable attachment-list)
+  ""
+  (let* ((display (drawable-display drawable))
+	 (len (length attachment-list) )
+	 (seq (make-array len :initial-contents attachment-list))
+	)
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-get-buffers+)
+				    (drawable drawable)
+				    (card32 len)
+				    (( sequence :format card32) seq))
+      ;; (let ((num (card32-get 16)))
+      ;; 	(values 
+      ;; 	 (card32-get 8)
+      ;; 	 (card32-get 12)
+      ;; 	 (loop :for buf :from 1 :to num
+      ;; 	       :for offset := 32 :then (+ offset 20)
+      ;; 	       :collect (make-dri2-buffer :attachment (card32-get offset)
+      ;; 					  :name       (card32-get (+ offset 4))
+      ;; 					  :pitch (card32-get (+ offset 8))
+      ;; 					  :cpp (card32-get (+ offset 12))
+      ;; 					  :flags (card32-get (+ offset 16))))))
+      (values
+       (card32-get 16)
+       (card32-get 12)
+       (card32-get 8))
+      )))
+(defun dri2-copy-region (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-copy-region+))
+      (values))))
+
+(defun dri2-get-buffers-with-format (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-get-buffers-with-format+))
+      (values))))
+
+(defun dri2-swap-buffers (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-swap-buffers+))
+      (values))))
+(defun dri2-get-msc (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-get-msc+))
+      (values))))
+
+(defun dri2-wait-msc (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-wait-msc+))
+      (values))))
+
+(defun dri2-swap-interval ()
+  ""
+  (with-buffer-request (display (dri2-opcode display))
+    (data +dri2-swap-interval+)))
+
+(defun dri2-get-param (drawable)
+""
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (dri2-opcode display) nil)
+				   ((data +dri2-get-param+))
+      (values))))

--- a/extensions/gl.lisp
+++ b/extensions/gl.lisp
@@ -1,0 +1,3743 @@
+(defpackage :gl
+  (:use :common-lisp :xlib)
+  (:import-from :glx
+                "*CURRENT-CONTEXT*"
+                "CONTEXT"
+                "CONTEXT-P"
+                "CONTEXT-DISPLAY"
+                "CONTEXT-TAG"
+                "CONTEXT-RBUF"
+                "CONTEXT-INDEX"
+                )
+  (:import-from :xlib
+                "DATA"
+                "WITH-BUFFER-REQUEST"
+                "WITH-BUFFER-REQUEST-AND-REPLY"
+                "CARD32-GET"
+                "SEQUENCE-GET"
+
+                "WITH-DISPLAY"
+                "DISPLAY-FORCE-OUTPUT"
+
+                "INT8" "INT16" "INT32" "INTEGER"
+                "CARD8" "CARD16" "CARD32"
+
+                "ASET-CARD8"
+                "ASET-CARD16"
+                "ASET-CARD32"
+                "ASET-INT8"
+                "ASET-INT16"
+                "ASET-INT32"
+
+                "DECLARE-BUFFUN"
+
+                ;; Types
+                "ARRAY-INDEX"
+                "BUFFER-BYTES"
+                )
+
+  (:export "GET-STRING"
+
+           ;; Rendering commands (alphabetical order)
+
+           "ACCUM"
+           "ACTIVE-TEXTURE-ARB"
+           "ALPHA-FUNC"
+           "BEGIN"
+           "BIND-TEXTURE"
+           "BLEND-COLOR"
+           "BLEND-EQUOTION"
+           "BLEND-FUNC"
+           "CALL-LIST"
+           "CLEAR"
+           "CLEAR-ACCUM"
+           "CLEAR-COLOR"
+           "CLEAR-DEPTH"
+           "CLEAR-INDEX"
+           "CLEAR-STENCIL"
+           "CLIP-PLANE"
+           "COLOR-3B"
+           "COLOR-3D"
+           "COLOR-3F"
+           "COLOR-3I"
+           "COLOR-3S"
+           "COLOR-3UB"
+           "COLOR-3UI"
+           "COLOR-3US"
+           "COLOR-4B"
+           "COLOR-4D"
+           "COLOR-4F"
+           "COLOR-4I"
+           "COLOR-4S"
+           "COLOR-4UB"
+           "COLOR-4UI"
+           "COLOR-4US"
+           "COLOR-MASK"
+           "COLOR-MATERIAL"
+           "CONVOLUTION-PARAMETER-F"
+           "CONVOLUTION-PARAMETER-I"
+           "COPY-COLOR-SUB-TABLE"
+           "COPY-COLOR-TABLE"
+           "COPY-CONVOLUTION-FILTER-ID"
+           "COPY-CONVOLUTION-FILTER-2D"
+           "COPY-PIXELS"
+           "COPY-TEX-IMAGE-1D"
+           "COPY-TEX-IMAGE-2D"
+           "COPY-TEX-SUB-IMAGE-1D"
+           "COPY-TEX-SUB-IMAGE-2D"
+           "COPY-TEX-SUB-IMAGE-3D"
+           "CULL-FACE"
+           "DEPTH-FUNC"
+           "DEPTH-MASK"
+           "DEPTH-RANGE"
+           "DRAW-BUFFER"
+           "EDGE-FLAG-V"
+           "END"
+           "EVAL-COORD-1D"
+           "EVAL-COORD-1F"
+           "EVAL-COORD-2D"
+           "EVAL-COORD-2F"
+           "EVAL-MESH-1"
+           "EVAL-MESH-2"
+           "EVAL-POINT-1"
+           "EVAL-POINT-2"
+           "FOG-F"
+           "FOG-I"
+           "FRONT-FACE"
+           "FRUSTUM"
+           "HINT"
+           "HISTOGRAM"
+           "INDEX-MASK"
+           "INDEX-D"
+           "INDEX-F"
+           "INDEX-I"
+           "INDEX-S"
+           "INDEX-UB"
+           "INIT-NAMES"
+           "LIGHT-MODEL-F"
+           "LIGHT-MODEL-I"
+           "LIGHT-F"
+           "LIGHT-FV"
+           "LIGHT-I"
+           "LIGHT-IV"
+           "LINE-STIPPLE"
+           "LINE-WIDTH"
+           "LIST-BASE"
+           "LOAD-IDENTITY"
+           "LOAD-NAME"
+           "LOGIC-OP"
+           "MAP-GRID-1D"
+           "MAP-GRID-1F"
+           "MAP-GRID-2D"
+           "MAP-GRID-2F"
+           "MATERIAL-F"
+           "MATERIAL-FV"
+           "MATERIAL-I"
+           "MATERIAL-IV"
+           "MATRIX-MODE"
+           "MINMAX"
+           "MULTI-TEX-COORD-1D-ARB"
+           "MULTI-TEX-COORD-1F-ARB"
+           "MULTI-TEX-COORD-1I-ARB"
+           "MULTI-TEX-COORD-1S-ARB"
+           "MULTI-TEX-COORD-2D-ARB"
+           "MULTI-TEX-COORD-2F-ARB"
+           "MULTI-TEX-COORD-2I-ARB"
+           "MULTI-TEX-COORD-2S-ARB"
+           "MULTI-TEX-COORD-3D-ARB"
+           "MULTI-TEX-COORD-3F-ARB"
+           "MULTI-TEX-COORD-3I-ARB"
+           "MULTI-TEX-COORD-3S-ARB"
+           "MULTI-TEX-COORD-4D-ARB"
+           "MULTI-TEX-COORD-4F-ARB"
+           "MULTI-TEX-COORD-4I-ARB"
+           "MULTI-TEX-COORD-4S-ARB"
+           "NORMAL-3B"
+           "NORMAL-3D"
+           "NORMAL-3F"
+           "NORMAL-3I"
+           "NORMAL-3S"
+           "ORTHO"
+           "PASS-THROUGH"
+           "PIXEL-TRANSFER-F"
+           "PIXEL-TRANSFER-I"
+           "PIXEL-ZOOM"
+           "POINT-SIZE"
+           "POLYGON-MODE"
+           "POLYGON-OFFSET"
+           "POP-ATTRIB"
+           "POP-MATRIX"
+           "POP-NAME"
+           "PUSH-ATTRIB"
+           "PUSH-MATRIX"
+           "PUSH-NAME"
+           "RASTER-POS-2D"
+           "RASTER-POS-2F"
+           "RASTER-POS-2I"
+           "RASTER-POS-2S"
+           "RASTER-POS-3D"
+           "RASTER-POS-3F"
+           "RASTER-POS-3I"
+           "RASTER-POS-3S"
+           "RASTER-POS-4D"
+           "RASTER-POS-4F"
+           "RASTER-POS-4I"
+           "RASTER-POS-4S"
+           "READ-BUFFER"
+           "RECT-D"
+           "RECT-F"
+           "RECT-I"
+           "RECT-S"
+           "RESET-HISTOGRAM"
+           "RESET-MINMAX"
+           "ROTATE-D"
+           "ROTATE-F"
+           "SCALE-D"
+           "SCALE-F"
+           "SCISSOR"
+           "SHADE-MODEL"
+           "STENCIL-FUNC"
+           "STENCIL-MASK"
+           "STENCIL-OP"
+           "TEX-ENV-F"
+           "TEX-ENV-I"
+           "TEX-GEN-D"
+           "TEX-GEN-F"
+           "TEX-GEN-I"
+           "TEX-PARAMETER-F"
+           "TEX-PARAMETER-I"
+           "TRANSLATE-D"
+           "TRANSLATE-F"
+           "VERTEX-2D"
+           "VERTEX-2F"
+           "VERTEX-2I"
+           "VERTEX-2S"
+           "VERTEX-3D"
+           "VERTEX-3F"
+           "VERTEX-3I"
+           "VERTEX-3S"
+           "VERTEX-4D"
+           "VERTEX-4F"
+           "VERTEX-4I"
+           "VERTEX-4S"
+           "VIEWPORT"
+
+           ;; * Where did this come from?
+           ;;"NO-FLOATS"
+
+           ;; Non-rendering commands
+           "NEW-LIST"
+           "END-LIST"
+           "GEN-LISTS"
+           "ENABLE"
+           "DISABLE"
+           "FLUSH"
+           "FINISH"
+
+           ;; Constants
+
+           ;; Boolean
+
+           "+FALSE+"
+           "+TRUE+"
+
+           ;; Types
+
+           "+BYTE+"
+           "+UNSIGNED-BYTE+"
+           "+SHORT+"
+           "+UNSIGNED-SHORT+"
+           "+INT+"
+           "+UNSIGNED-INT+"
+           "+FLOAT+"
+           "+DOUBLE+"
+           "+2-BYTES+"
+           "+3-BYTES+"
+           "+4-BYTES+"
+
+           ;; Primitives
+
+           "+POINTS+"
+           "+LINES+"
+           "+LINE-LOOP+"
+           "+LINE-STRIP+"
+           "+TRIANGLES+"
+           "+TRIANGLE-STRIP+"
+           "+triangle-fan+"
+           "+QUADS+"
+           "+QUAD-STRIP+"
+           "+POLYGON+"
+
+           ;; Arrays
+
+           "+VERTEX-ARRAY+"
+           "+NORMAL-ARRAY+"
+           "+COLOR-ARRAY+"
+           "+INDEX-ARRAY+"
+           "+TEXTURE-COORD-ARRAY+"
+           "+EDGE-FLAG-ARRAY+"
+           "+VERTEX-ARRAY-SIZE+"
+           "+VERTEX-ARRAY-TYPE+"
+           "+VERTEX-ARRAY-STRIDE+"
+           "+NORMAL-ARRAY-TYPE+"
+           "+NORMAL-ARRAY-STRIDE+"
+           "+COLOR-ARRAY-SIZE+"
+           "+COLOR-ARRAY-TYPE+"
+           "+COLOR-ARRAY-STRIDE+"
+           "+INDEX-ARRAY-TYPE+"
+           "+INDEX-ARRAY-STRIDE+"
+           "+TEXTURE-COORD-ARRAY-SIZE+"
+           "+TEXTURE-COORD-ARRAY-TYPE+"
+           "+TEXTURE-COORD-ARRAY-STRIDE+"
+           "+EDGE-FLAG-ARRAY-STRIDE+"
+           "+VERTEX-ARRAY-POINTER+"
+           "+NORMAL-ARRAY-POINTER+"
+           "+COLOR-ARRAY-POINTER+"
+           "+INDEX-ARRAY-POINTER+"
+           "+TEXTURE-COORD-ARRAY-POINTER+"
+           "+EDGE-FLAG-ARRAY-POINTER+"
+
+           ;; Array formats
+
+           "+V2F+"
+           "+V3F+"
+           "+C4UB-V2F+"
+           "+C4UB-V3F+"
+           "+C3F-V3F+"
+           "+N3F-V3F+"
+           "+C4F-N3F-V3F+"
+           "+T2F-V3F+"
+           "+T4F-V4F+"
+           "+T2F-C4UB-V3F+"
+           "+T2F-C3F-V3F+"
+           "+T2F-N3F-V3F+"
+           "+T2F-C4F-N3F-V3F+"
+           "+T4F-C4F-N3F-V4F+"
+
+           ;; Matrices
+
+           "+MATRIX-MODE+"
+           "+MODELVIEW+"
+           "+PROJECTION+"
+           "+TEXTURE+"
+
+           ;; Points
+
+           "+POINT-SMOOTH+"
+           "+POINT-SIZE+"
+           "+POINT-SIZE-GRANULARITY+"
+           "+POINT-SIZE-RANGE+"
+
+           ;; Lines
+
+           "+LINE-SMOOTH+"
+           "+LINE-STIPPLE+"
+           "+LINE-STIPPLE-PATTERN+"
+           "+LINE-STIPPLE-REPEAT+"
+           "+LINE-WIDTH+"
+           "+LINE-WIDTH-GRANULARITY+"
+           "+LINE-WIDTH-RANGE+"
+
+           ;; Polygons
+
+           "+POINT+"
+           "+LINE+"
+           "+FILL+"
+           "+CW+"
+           "+CCW+"
+           "+FRONT+"
+           "+BACK+"
+           "+POLYGON-MODE+"
+           "+POLYGON-SMOOTH+"
+           "+POLYGON-STIPPLE+"
+           "+EDGE-FLAG+"
+           "+CULL-FACE+"
+           "+CULL-FACE-MODE+"
+           "+FRONT-FACE+"
+           "+POLYGON-OFFSET-FACTOR+"
+           "+POLYGON-OFFSET-UNITS+"
+           "+POLYGON-OFFSET-POINT+"
+           "+POLYGON-OFFSET-LINE+"
+           "+POLYGON-OFFSET-FILL+"
+
+           ;; Display Lists
+
+           "+COMPILE+"
+           "+COMPILE-AND-EXECUTE+"
+           "+LIST-BASE+"
+           "+LIST-INDEX+"
+           "+LIST-MODE+"
+
+           ;; Depth Buffer
+
+           "+NEVER+"
+           "+LESS+"
+           "+EQUAL+"
+           "+LEQUAL+"
+           "+GREATER+"
+           "+NOTEQUAL+"
+           "+GEQUAL+"
+           "+ALWAYS+"
+           "+DEPTH-TEST+"
+           "+DEPTH-BITS+"
+           "+DEPTH-CLEAR-VALUE+"
+           "+DEPTH-FUNC+"
+           "+DEPTH-RANGE+"
+           "+DEPTH-WRITEMASK+"
+           "+DEPTH-COMPONENT+"
+
+           ;; Lighting
+
+           "+LIGHTING+"
+           "+LIGHT0+"
+           "+LIGHT1+"
+           "+LIGHT2+"
+           "+LIGHT3+"
+           "+LIGHT4+"
+           "+LIGHT5+"
+           "+LIGHT6+"
+           "+LIGHT7+"
+           "+SPOT-EXPONENT+"
+           "+SPOT-CUTOFF+"
+           "+CONSTANT-ATTENUATION+"
+           "+LINEAR-ATTENUATION+"
+           "+QUADRATIC-ATTENUATION+"
+           "+AMBIENT+"
+           "+DIFFUSE+"
+           "+SPECULAR+"
+           "+SHININESS+"
+           "+EMISSION+"
+           "+POSITION+"
+           "+SPOT-DIRECTION+"
+           "+AMBIENT-AND-DIFFUSE+"
+           "+COLOR-INDEXES+"
+           "+LIGHT-MODEL-TWO-SIDE+"
+           "+LIGHT-MODEL-LOCAL-VIEWER+"
+           "+LIGHT-MODEL-AMBIENT+"
+           "+FRONT-AND-BACK+"
+           "+SHADE-MODEL+"
+           "+FLAT+"
+           "+SMOOTH+"
+           "+COLOR-MATERIAL+"
+           "+COLOR-MATERIAL-FACE+"
+           "+COLOR-MATERIAL-PARAMETER+"
+           "+NORMALIZE+"
+
+           ;; Clipping planes
+
+           "+CLIP-PLANE0+"
+           "+CLIP-PLANE1+"
+           "+CLIP-PLANE2+"
+           "+CLIP-PLANE3+"
+           "+CLIP-PLANE4+"
+           "+CLIP-PLANE5+"
+
+           ;; Accumulation buffer
+
+           "+ACCUM-RED-BITS+"
+           "+ACCUM-GREEN-BITS+"
+           "+ACCUM-BLUE-BITS+"
+           "+ACCUM-ALPHA-BITS+"
+           "+ACCUM-CLEAR-VALUE+"
+           "+ACCUM+"
+           "+ADD+"
+           "+LOAD+"
+           "+MULT+"
+           "+RETURN+"
+
+           ;; Alpha Testing
+
+           "+ALPHA-TEST+"
+           "+ALPHA-TEST-REF+"
+           "+ALPHA-TEST-FUNC+"
+
+           ;; Blending
+
+           "+BLEND+"
+           "+BLEND-SRC+"
+           "+BLEND-DST+"
+           "+ZERO+"
+           "+ONE+"
+           "+SRC-COLOR+"
+           "+ONE-MINUS-SRC-COLOR+"
+           "+DST-COLOR+"
+           "+ONE-MINUS-DST-COLOR+"
+           "+SRC-ALPHA+"
+           "+ONE-MINUS-SRC-ALPHA+"
+           "+DST-ALPHA+"
+           "+ONE-MINUS-DST-ALPHA+"
+           "+SRC-ALPHA-SATURATE+"
+           "+CONSTANT-COLOR+"
+           "+ONE-MINUS-CONSTANT-COLOR+"
+           "+CONSTANT-ALPHA+"
+           "+ONE-MINUS-CONSTANT-ALPHA+"
+
+           ;; Render mode
+
+           "+FEEDBACK+"
+           "+RENDER+"
+           "+SELECT+"
+
+           ;; Feedback
+
+           "+2D+"
+           "+3D+"
+           "+3D-COLOR+"
+           "+3D-COLOR-TEXTURE+"
+           "+4D-COLOR-TEXTURE+"
+           "+POINT-TOKEN+"
+           "+LINE-TOKEN+"
+           "+LINE-RESET-TOKEN+"
+           "+POLYGON-TOKEN+"
+           "+BITMAP-TOKEN+"
+           "+DRAW-PIXEL-TOKEN+"
+           "+COPY-PIXEL-TOKEN+"
+           "+PASS-THROUGH-TOKEN+"
+           "+FEEDBACK-BUFFER-POINTER+"
+           "+FEEDBACK-BUFFER-SIZE+"
+           "+FEEDBACK-BUFFER-TYPE+"
+
+           ;; Selection
+
+           "+SELECTION-BUFFER-POINTER+"
+           "+SELECTION-BUFFER-SIZE+"
+
+           ;; Fog
+
+           "+FOG+"
+           "+FOG-MODE+"
+           "+FOG-DENSITY+"
+           "+FOG-COLOR+"
+           "+FOG-INDEX+"
+           "+FOG-START+"
+           "+FOG-END+"
+           "+LINEAR+"
+           "+EXP+"
+           "+EXP2+"
+
+           ;; Logic operations
+
+           "+LOGIC-OP+"
+           "+INDEX-LOGIC-OP+"
+           "+COLOR-LOGIC-OP+"
+           "+LOGIC-OP-MODE+"
+           "+CLEAR+"
+           "+SET+"
+           "+COPY+"
+           "+COPY-INVERTED+"
+           "+NOOP+"
+           "+INVERT+"
+           "+AND+"
+           "+NAND+"
+           "+OR+"
+           "+NOR+"
+           "+XOR+"
+           "+EQUIV+"
+           "+AND-REVERSE+"
+           "+AND-INVERTED+"
+           "+OR-REVERSE+"
+           "+OR-INVERTED+"
+
+           ;; Stencil
+
+           "+STENCIL-TEST+"
+           "+STENCIL-WRITEMASK+"
+           "+STENCIL-BITS+"
+           "+STENCIL-FUNC+"
+           "+STENCIL-VALUE-MASK+"
+           "+STENCIL-REF+"
+           "+STENCIL-FAIL+"
+           "+STENCIL-PASS-DEPTH-PASS+"
+           "+STENCIL-PASS-DEPTH-FAIL+"
+           "+STENCIL-CLEAR-VALUE+"
+           "+STENCIL-INDEX+"
+           "+KEEP+"
+           "+REPLACE+"
+           "+INCR+"
+           "+DECR+"
+
+           ;; Buffers, Pixel Drawing/Reading
+
+           "+NONE+"
+           "+LEFT+"
+           "+RIGHT+"
+           "+FRONT-LEFT+"
+           "+FRONT-RIGHT+"
+           "+BACK-LEFT+"
+           "+BACK-RIGHT+"
+           "+AUX0+"
+           "+AUX1+"
+           "+AUX2+"
+           "+AUX3+"
+           "+COLOR-INDEX+"
+           "+RED+"
+           "+GREEN+"
+           "+BLUE+"
+           "+ALPHA+"
+           "+LUMINANCE+"
+           "+LUMINANCE-ALPHA+"
+           "+ALPHA-BITS+"
+           "+RED-BITS+"
+           "+GREEN-BITS+"
+           "+BLUE-BITS+"
+           "+INDEX-BITS+"
+           "+SUBPIXEL-BITS+"
+           "+AUX-BUFFERS+"
+           "+READ-BUFFER+"
+           "+DRAW-BUFFER+"
+           "+DOUBLEBUFFER+"
+           "+STEREO+"
+           "+BITMAP+"
+           "+COLOR+"
+           "+DEPTH+"
+           "+STENCIL+"
+           "+DITHER+"
+           "+RGB+"
+           "+RGBA+"
+
+           ;; Implementation Limits
+
+           "+MAX-LIST-NESTING+"
+           "+MAX-ATTRIB-STACK-DEPTH+"
+           "+MAX-MODELVIEW-STACK-DEPTH+"
+           "+MAX-NAME-STACK-DEPTH+"
+           "+MAX-PROJECTION-STACK-DEPTH+"
+           "+MAX-TEXTURE-STACK-DEPTH+"
+           "+MAX-EVAL-ORDER+"
+           "+MAX-LIGHTS+"
+           "+MAX-CLIP-PLANES+"
+           "+MAX-TEXTURE-SIZE+"
+           "+MAX-PIXEL-MAP-TABLE+"
+           "+MAX-VIEWPORT-DIMS+"
+           "+MAX-CLIENT-ATTRIB-STACK-DEPTH+"
+
+           ;; Gets
+
+           "+ATTRIB-STACK-DEPTH+"
+           "+CLIENT-ATTRIB-STACK-DEPTH+"
+           "+COLOR-CLEAR-VALUE+"
+           "+COLOR-WRITEMASK+"
+           "+CURRENT-INDEX+"
+           "+CURRENT-COLOR+"
+           "+CURRENT-NORMAL+"
+           "+CURRENT-RASTER-COLOR+"
+           "+CURRENT-RASTER-DISTANCE+"
+           "+current-raster-index+"
+           "+CURRENT-RASTER-POSITION+"
+           "+CURRENT-RASTER-TEXTURE-COORDS+"
+           "+CURRENT-RASTER-POSITION-VALID+"
+           "+CURRENT-TEXTURE-COORDS+"
+           "+INDEX-CLEAR-VALUE+"
+           "+INDEX-MODE+"
+           "+INDEX-WRITEMASK+"
+           "+MODELVIEW-MATRIX+"
+           "+MODELVIEW-STACK-DEPTH+"
+           "+NAME-STACK-DEPTH+"
+           "+PROJECTION-MATRIX+"
+           "+PROJECTION-STACK-DEPTH+"
+           "+RENDER-MODE+"
+           "+RGBA-MODE+"
+           "+TEXTURE-MATRIX+"
+           "+TEXTURE-STACK-DEPTH+"
+           "+VIEWPORT+"
+
+           ;; GL Evaluators
+
+           "+AUTO-NORMAL+"
+           "+MAP1-COLOR-4+"
+           "+MAP1-GRID-DOMAIN+"
+           "+MAP1-GRID-SEGMENTS+"
+           "+MAP1-INDEX+"
+           "+MAP1-NORMAL+"
+           "+MAP1-TEXTURE-COORD-1+"
+           "+MAP1-TEXTURE-COORD-2+"
+           "+MAP1-TEXTURE-COORD-3+"
+           "+MAP1-TEXTURE-COORD-4+"
+           "+MAP1-VERTEX-3+"
+           "+MAP1-VERTEX-4+"
+           "+MAP2-COLOR-4+"
+           "+MAP2-GRID-DOMAIN+"
+           "+MAP2-GRID-SEGMENTS+"
+           "+MAP2-INDEX+"
+           "+MAP2-NORMAL+"
+           "+MAP2-TEXTURE-COORD-1+"
+           "+MAP2-TEXTURE-COORD-2+"
+           "+MAP2-TEXTURE-COORD-3+"
+           "+MAP2-TEXTURE-COORD-4+"
+           "+MAP2-VERTEX-3+"
+           "+MAP2-VERTEX-4+"
+           "+COEFF+"
+           "+DOMAIN+"
+           "+ORDER+"
+
+           ;; Hints
+
+           "+FOG-HINT+"
+           "+LINE-SMOOTH-HINT+"
+           "+PERSPECTIVE-CORRECTION-HINT+"
+           "+POINT-SMOOTH-HINT+"
+           "+POLYGON-SMOOTH-HINT+"
+           "+DONT-CARE+"
+           "+FASTEST+"
+           "+NICEST+"
+
+           ;; Scissor box
+
+           "+SCISSOR-TEST+"
+           "+SCISSOR-BOX+"
+
+           ;; Pixel Mode / Transfer
+
+           "+MAP-COLOR+"
+           "+MAP-STENCIL+"
+           "+INDEX-SHIFT+"
+           "+INDEX-OFFSET+"
+           "+RED-SCALE+"
+           "+RED-BIAS+"
+           "+GREEN-SCALE+"
+           "+GREEN-BIAS+"
+           "+BLUE-SCALE+"
+           "+BLUE-BIAS+"
+           "+ALPHA-SCALE+"
+           "+ALPHA-BIAS+"
+           "+DEPTH-SCALE+"
+           "+DEPTH-BIAS+"
+           "+PIXEL-MAP-S-TO-S-SIZE+"
+           "+PIXEL-MAP-I-TO-I-SIZE+"
+           "+PIXEL-MAP-I-TO-R-SIZE+"
+           "+PIXEL-MAP-I-TO-G-SIZE+"
+           "+PIXEL-MAP-I-TO-B-SIZE+"
+           "+PIXEL-MAP-I-TO-A-SIZE+"
+           "+PIXEL-MAP-R-TO-R-SIZE+"
+           "+PIXEL-MAP-G-TO-G-SIZE+"
+           "+PIXEL-MAP-B-TO-B-SIZE+"
+           "+PIXEL-MAP-A-TO-A-SIZE+"
+           "+PIXEL-MAP-S-TO-S+"
+           "+PIXEL-MAP-I-TO-I+"
+           "+PIXEL-MAP-I-TO-R+"
+           "+PIXEL-MAP-I-TO-G+"
+           "+PIXEL-MAP-I-TO-B+"
+           "+PIXEL-MAP-I-TO-A+"
+           "+PIXEL-MAP-R-TO-R+"
+           "+PIXEL-MAP-G-TO-G+"
+           "+PIXEL-MAP-B-TO-B+"
+           "+PIXEL-MAP-A-TO-A+"
+           "+PACK-ALIGNMENT+"
+           "+PACK-LSB-FIRST+"
+           "+PACK-ROW-LENGTH+"
+           "+PACK-SKIP-PIXELS+"
+           "+PACK-SKIP-ROWS+"
+           "+PACK-SWAP-BYTES+"
+           "+UNPACK-ALIGNMENT+"
+           "+UNPACK-LSB-FIRST+"
+           "+UNPACK-ROW-LENGTH+"
+           "+UNPACK-SKIP-PIXELS+"
+           "+UNPACK-SKIP-ROWS+"
+           "+UNPACK-SWAP-BYTES+"
+           "+ZOOM-X+"
+           "+ZOOM-Y+"
+
+           ;; Texture Mapping
+
+           "+TEXTURE-ENV+"
+           "+TEXTURE-ENV-MODE+"
+           "+TEXTURE-1D+"
+           "+TEXTURE-2D+"
+           "+TEXTURE-WRAP-S+"
+           "+TEXTURE-WRAP-T+"
+           "+TEXTURE-MAG-FILTER+"
+           "+TEXTURE-MIN-FILTER+"
+           "+TEXTURE-ENV-COLOR+"
+           "+TEXTURE-GEN-S+"
+           "+TEXTURE-GEN-T+"
+           "+TEXTURE-GEN-MODE+"
+           "+TEXTURE-BORDER-COLOR+"
+           "+TEXTURE-WIDTH+"
+           "+TEXTURE-HEIGHT+"
+           "+TEXTURE-BORDER+"
+           "+TEXTURE-COMPONENTS+"
+           "+TEXTURE-RED-SIZE+"
+           "+TEXTURE-GREEN-SIZE+"
+           "+TEXTURE-BLUE-SIZE+"
+           "+TEXTURE-ALPHA-SIZE+"
+           "+TEXTURE-LUMINANCE-SIZE+"
+           "+TEXTURE-INTENSITY-SIZE+"
+           "+NEAREST-MIPMAP-NEAREST+"
+           "+NEAREST-MIPMAP-LINEAR+"
+           "+LINEAR-MIPMAP-NEAREST+"
+           "+LINEAR-MIPMAP-LINEAR+"
+           "+OBJECT-LINEAR+"
+           "+OBJECT-PLANE+"
+           "+EYE-LINEAR+"
+           "+EYE-PLANE+"
+           "+SPHERE-MAP+"
+           "+DECAL+"
+           "+MODULATE+"
+           "+NEAREST+"
+           "+REPEAT+"
+           "+CLAMP+"
+           "+S+"
+           "+T+"
+           "+R+"
+           "+Q+"
+           "+TEXTURE-GEN-R+"
+           "+TEXTURE-GEN-Q+"
+
+           ;; GL 1.1 Texturing
+
+           "+PROXY-TEXTURE-1D+"
+           "+PROXY-TEXTURE-2D+"
+           "+TEXTURE-PRIORITY+"
+           "+TEXTURE-RESIDENT+"
+           "+TEXTURE-BINDING-1D+"
+           "+TEXTURE-BINDING-2D+"
+           "+TEXTURE-INTERNAL-FORMAT+"
+           "+PACK-SKIP-IMAGES+"
+           "+PACK-IMAGE-HEIGHT+"
+           "+UNPACK-SKIP-IMAGES+"
+           "+UNPACK-IMAGE-HEIGHT+"
+           "+TEXTURE-3D+"
+           "+PROXY-TEXTURE-3D+"
+           "+TEXTURE-DEPTH+"
+           "+TEXTURE-WRAP-R+"
+           "+MAX-3D-TEXTURE-SIZE+"
+           "+TEXTURE-BINDING-3D+"
+
+           ;; Internal texture formats (GL 1.1)
+           "+ALPHA4+"
+           "+ALPHA8+"
+           "+ALPHA12+"
+           "+ALPHA16+"
+           "+LUMINANCE4+"
+           "+LUMINANCE8+"
+           "+LUMINANCE12+"
+           "+LUMINANCE16+"
+           "+LUMINANCE4-ALPHA4+"
+           "+LUMINANCE6-ALPHA2+"
+           "+LUMINANCE8-ALPHA8+"
+           "+LUMINANCE12-ALPHA4+"
+           "+LUMINANCE12-ALPHA12+"
+           "+LUMINANCE16-ALPHA16+"
+           "+INTENSITY+"
+           "+INTENSITY4+"
+           "+INTENSITY8+"
+           "+INTENSITY12+"
+           "+INTENSITY16+"
+           "+R3-G3-B2+"
+           "+RGB4+"
+           "+RGB5+"
+           "+RGB8+"
+           "+RGB10+"
+           "+RGB12+"
+           "+RGB16+"
+           "+RGBA2+"
+           "+RGBA4+"
+           "+RGB5-A1+"
+           "+RGBA8+"
+           "+rgb10-a2+"
+           "+RGBA12+"
+           "+RGBA16+"
+
+           ;; Utility
+
+           "+VENDOR+"
+           "+RENDERER+"
+           "+VERSION+"
+           "+EXTENSIONS+"
+
+           ;; Errors
+
+           "+NO-ERROR+"
+           "+INVALID-VALUE+"
+           "+INVALID-ENUM+"
+           "+INVALID-OPERATION+"
+           "+STACK-OVERFLOW+"
+           "+STACK-UNDERFLOW+"
+           "+OUT-OF-MEMORY+"
+
+           ;; OpenGL 1.2
+
+           "+RESCALE-NORMAL+"
+           "+CLAMP-TO-EDGE+"
+           "+MAX-ELEMENTS-VERTICES+"
+           "+MAX-ELEMENTS-INDICES+"
+           "+BGR+"
+           "+BGRA+"
+           "+UNSIGNED-BYTE-3-3-2+"
+           "+UNSIGNED-BYTE-2-3-3-REV+"
+           "+UNSIGNED-SHORT-5-6-5+"
+           "+UNSIGNED-SHORT-5-6-5-REV+"
+           "+UNSIGNED-SHORT-4-4-4-4+"
+           "+UNSIGNED-SHORT-4-4-4-4-REV+"
+           "+UNSIGNED-SHORT-5-5-5-1+"
+           "+UNSIGNED-SHORT-1-5-5-5-REV+"
+           "+UNSIGNED-INT-8-8-8-8+"
+           "+UNSIGNED-INT-8-8-8-8-REV+"
+           "+UNSIGNED-INT-10-10-10-2+"
+           "+UNSIGNED-INT-2-10-10-10-REV+"
+           "+LIGHT-MODEL-COLOR-CONTROL+"
+           "+SINGLE-COLOR+"
+           "+SEPARATE-SPECULAR-COLOR+"
+           "+TEXTURE-MIN-LOD+"
+           "+TEXTURE-MAX-LOD+"
+           "+TEXTURE-BASE-LEVEL+"
+           "+TEXTURE-MAX-LEVEL+"
+           "+SMOOTH-POINT-SIZE-RANGE+"
+           "+SMOOTH-POINT-SIZE-GRANULARITY+"
+           "+SMOOTH-LINE-WIDTH-RANGE+"
+           "+SMOOTH-LINE-WIDTH-GRANULARITY+"
+           "+ALIASED-POINT-SIZE-RANGE+"
+           "+ALIASED-LINE-WIDTH-RANGE+"
+
+           ;; OpenGL 1.2 Imaging subset
+           ;; GL_EXT_color_table
+           "+COLOR-TABLE+"
+           "+POST-CONVOLUTION-COLOR-TABLE+"
+           "+POST-COLOR-MATRIX-COLOR-TABLE+"
+           "+PROXY-COLOR-TABLE+"
+           "+PROXY-POST-CONVOLUTION-COLOR-TABLE+"
+           "+PROXY-POST-COLOR-MATRIX-COLOR-TABLE+"
+           "+COLOR-TABLE-SCALE+"
+           "+COLOR-TABLE-BIAS+"
+           "+COLOR-TABLE-FORMAT+"
+           "+COLOR-TABLE-WIDTH+"
+           "+COLOR-TABLE-RED-SIZE+"
+           "+COLOR-TABLE-GREEN-SIZE+"
+           "+COLOR-TABLE-BLUE-SIZE+"
+           "+COLOR-TABLE-ALPHA-SIZE+"
+           "+COLOR-TABLE-LUMINANCE-SIZE+"
+           "+COLOR-TABLE-INTENSITY-SIZE+"
+           ;; GL_EXT_convolution and GL_HP_convolution
+           "+CONVOLUTION-1D+"
+           "+CONVOLUTION-2D+"
+           "+SEPARABLE-2D+"
+           "+CONVOLUTION-BORDER-MODE+"
+           "+CONVOLUTION-FILTER-SCALE+"
+           "+CONVOLUTION-FILTER-BIAS+"
+           "+REDUCE+"
+           "+CONVOLUTION-FORMAT+"
+           "+CONVOLUTION-WIDTH+"
+           "+CONVOLUTION-HEIGHT+"
+           "+MAX-CONVOLUTION-WIDTH+"
+           "+MAX-CONVOLUTION-HEIGHT+"
+           "+POST-CONVOLUTION-RED-SCALE+"
+           "+POST-CONVOLUTION-GREEN-SCALE+"
+           "+POST-CONVOLUTION-BLUE-SCALE+"
+           "+POST-CONVOLUTION-ALPHA-SCALE+"
+           "+POST-CONVOLUTION-RED-BIAS+"
+           "+POST-CONVOLUTION-GREEN-BIAS+"
+           "+POST-CONVOLUTION-BLUE-BIAS+"
+           "+POST-CONVOLUTION-ALPHA-BIAS+"
+           "+CONSTANT-BORDER+"
+           "+REPLICATE-BORDER+"
+           "+CONVOLUTION-BORDER-COLOR+"
+           ;; GL_SGI_color_matrix
+           "+COLOR-MATRIX+"
+           "+COLOR-MATRIX-STACK-DEPTH+"
+           "+MAX-COLOR-MATRIX-STACK-DEPTH+"
+           "+POST-COLOR-MATRIX-RED-SCALE+"
+           "+POST-COLOR-MATRIX-GREEN-SCALE+"
+           "+POST-COLOR-MATRIX-BLUE-SCALE+"
+           "+POST-COLOR-MATRIX-ALPHA-SCALE+"
+           "+POST-COLOR-MATRIX-RED-BIAS+"
+           "+POST-COLOR-MATRIX-GREEN-BIAS+"
+           "+POST-COLOR-MATRIX-BLUE-BIAS+"
+           "+POST-COLOR-MATRIX-ALPHA-BIAS+"
+           ;; GL_EXT_histogram
+           "+HISTOGRAM+"
+           "+PROXY-HISTOGRAM+"
+           "+HISTOGRAM-WIDTH+"
+           "+HISTOGRAM-FORMAT+"
+           "+HISTOGRAM-RED-SIZE+"
+           "+HISTOGRAM-GREEN-SIZE+"
+           "+HISTOGRAM-BLUE-SIZE+"
+           "+HISTOGRAM-ALPHA-SIZE+"
+           "+HISTOGRAM-LUMINANCE-SIZE+"
+           "+HISTOGRAM-SINK+"
+           "+MINMAX+"
+           "+MINMAX-FORMAT+"
+           "+MINMAX-SINK+"
+           "+TABLE-TOO-LARGE+"
+           ;; GL_EXT_blend_color, GL_EXT_blend_minmax
+           "+BLEND-EQUATION+"
+           "+MIN+"
+           "+MAX+"
+           "+FUNC-ADD+"
+           "+FUNC-SUBTRACT+"
+           "+FUNC-REVERSE-SUBTRACT+"
+
+           ;; glPush/PopAttrib bits
+
+           "+CURRENT-BIT+"
+           "+POINT-BIT+"
+           "+LINE-BIT+"
+           "+POLYGON-BIT+"
+           "+POLYGON-STIPPLE-BIT+"
+           "+PIXEL-MODE-BIT+"
+           "+LIGHTING-BIT+"
+           "+FOG-BIT+"
+           "+DEPTH-BUFFER-BIT+"
+           "+ACCUM-BUFFER-BIT+"
+           "+STENCIL-BUFFER-BIT+"
+           "+VIEWPORT-BIT+"
+           "+TRANSFORM-BIT+"
+           "+ENABLE-BIT+"
+           "+COLOR-BUFFER-BIT+"
+           "+HINT-BIT+"
+           "+EVAL-BIT+"
+           "+LIST-BIT+"
+           "+TEXTURE-BIT+"
+           "+SCISSOR-BIT+"
+           "+ALL-ATTRIB-BITS+"
+           "+CLIENT-PIXEL-STORE-BIT+"
+           "+CLIENT-VERTEX-ARRAY-BIT+"
+           "+CLIENT-ALL-ATTRIB-BITS+"
+
+           ;; ARB Multitexturing extension
+
+           "+ARB-MULTITEXTURE+"
+           "+TEXTURE0-ARB+"
+           "+TEXTURE1-ARB+"
+           "+TEXTURE2-ARB+"
+           "+TEXTURE3-ARB+"
+           "+TEXTURE4-ARB+"
+           "+TEXTURE5-ARB+"
+           "+TEXTURE6-ARB+"
+           "+TEXTURE7-ARB+"
+           "+TEXTURE8-ARB+"
+           "+TEXTURE9-ARB+"
+           "+TEXTURE10-ARB+"
+           "+TEXTURE11-ARB+"
+           "+TEXTURE12-ARB+"
+           "+TEXTURE13-ARB+"
+           "+TEXTURE14-ARB+"
+           "+TEXTURE15-ARB+"
+           "+TEXTURE16-ARB+"
+           "+TEXTURE17-ARB+"
+           "+TEXTURE18-ARB+"
+           "+TEXTURE19-ARB+"
+           "+TEXTURE20-ARB+"
+           "+TEXTURE21-ARB+"
+           "+TEXTURE22-ARB+"
+           "+TEXTURE23-ARB+"
+           "+TEXTURE24-ARB+"
+           "+TEXTURE25-ARB+"
+           "+TEXTURE26-ARB+"
+           "+TEXTURE27-ARB+"
+           "+TEXTURE28-ARB+"
+           "+TEXTURE29-ARB+"
+           "+TEXTURE30-ARB+"
+           "+TEXTURE31-ARB+"
+           "+ACTIVE-TEXTURE-ARB+"
+           "+CLIENT-ACTIVE-TEXTURE-ARB+"
+           "+MAX-TEXTURE-UNITS-ARB+"
+
+;;; Misc extensions
+
+           "+EXT-ABGR+"
+           "+ABGR-EXT+"
+           "+EXT-BLEND-COLOR+"
+           "+CONSTANT-COLOR-EXT+"
+           "+ONE-MINUS-CONSTANT-COLOR-EXT+"
+           "+CONSTANT-ALPHA-EXT+"
+           "+ONE-MINUS-CONSTANT-ALPHA-EXT+"
+           "+blend-color-ext+"
+           "+EXT-POLYGON-OFFSET+"
+           "+POLYGON-OFFSET-EXT+"
+           "+POLYGON-OFFSET-FACTOR-EXT+"
+           "+POLYGON-OFFSET-BIAS-EXT+"
+           "+EXT-TEXTURE3D+"
+           "+PACK-SKIP-IMAGES-EXT+"
+           "+PACK-IMAGE-HEIGHT-EXT+"
+           "+UNPACK-SKIP-IMAGES-EXT+"
+           "+UNPACK-IMAGE-HEIGHT-EXT+"
+           "+TEXTURE-3D-EXT+"
+           "+PROXY-TEXTURE-3D-EXT+"
+           "+TEXTURE-DEPTH-EXT+"
+           "+TEXTURE-WRAP-R-EXT+"
+           "+MAX-3D-TEXTURE-SIZE-EXT+"
+           "+TEXTURE-3D-BINDING-EXT+"
+           "+EXT-TEXTURE-OBJECT+"
+           "+TEXTURE-PRIORITY-EXT+"
+           "+TEXTURE-RESIDENT-EXT+"
+           "+TEXTURE-1D-BINDING-EXT+"
+           "+TEXTURE-2D-BINDING-EXT+"
+           "+EXT-RESCALE-NORMAL+"
+           "+RESCALE-NORMAL-EXT+"
+           "+EXT-VERTEX-ARRAY+"
+           "+VERTEX-ARRAY-EXT+"
+           "+NORMAL-ARRAY-EXT+"
+           "+COLOR-ARRAY-EXT+"
+           "+INDEX-ARRAY-EXT+"
+           "+TEXTURE-COORD-ARRAY-EXT+"
+           "+EDGE-FLAG-ARRAY-EXT+"
+           "+VERTEX-ARRAY-SIZE-EXT+"
+           "+VERTEX-ARRAY-TYPE-EXT+"
+           "+VERTEX-ARRAY-STRIDE-EXT+"
+           "+VERTEX-ARRAY-COUNT-EXT+"
+           "+NORMAL-ARRAY-TYPE-EXT+"
+           "+NORMAL-ARRAY-STRIDE-EXT+"
+           "+NORMAL-ARRAY-COUNT-EXT+"
+           "+COLOR-ARRAY-SIZE-EXT+"
+           "+COLOR-ARRAY-TYPE-EXT+"
+           "+COLOR-ARRAY-STRIDE-EXT+"
+           "+COLOR-ARRAY-COUNT-EXT+"
+           "+INDEX-ARRAY-TYPE-EXT+"
+           "+INDEX-ARRAY-STRIDE-EXT+"
+           "+INDEX-ARRAY-COUNT-EXT+"
+           "+TEXTURE-COORD-ARRAY-SIZE-EXT+"
+           "+TEXTURE-COORD-ARRAY-TYPE-EXT+"
+           "+TEXTURE-COORD-ARRAY-STRIDE-EXT+"
+           "+TEXTURE-COORD-ARRAY-COUNT-EXT+"
+           "+EDGE-FLAG-ARRAY-STRIDE-EXT+"
+           "+EDGE-FLAG-ARRAY-COUNT-EXT+"
+           "+VERTEX-ARRAY-POINTER-EXT+"
+           "+NORMAL-ARRAY-POINTER-EXT+"
+           "+COLOR-ARRAY-POINTER-EXT+"
+           "+INDEX-ARRAY-POINTER-EXT+"
+           "+TEXTURE-COORD-ARRAY-POINTER-EXT+"
+           "+EDGE-FLAG-ARRAY-POINTER-EXT+"
+           "+SGIS-TEXTURE-EDGE-CLAMP+"
+           "+CLAMP-TO-EDGE-SGIS+"
+           "+EXT-BLEND-MINMAX+"
+           "+FUNC-ADD-EXT+"
+           "+MIN-EXT+"
+           "+MAX-EXT+"
+           "+BLEND-EQUATION-EXT+"
+           "+EXT-BLEND-SUBTRACT+"
+           "+FUNC-SUBTRACT-EXT+"
+           "+FUNC-REVERSE-SUBTRACT-EXT+"
+           "+EXT-BLEND-LOGIC-OP+"
+           "+EXT-POINT-PARAMETERS+"
+           "+POINT-SIZE-MIN-EXT+"
+           "+POINT-SIZE-MAX-EXT+"
+           "+POINT-FADE-THRESHOLD-SIZE-EXT+"
+           "+DISTANCE-ATTENUATION-EXT+"
+           "+EXT-PALETTED-TEXTURE+"
+           "+TABLE-TOO-LARGE-EXT+"
+           "+COLOR-TABLE-FORMAT-EXT+"
+           "+COLOR-TABLE-WIDTH-EXT+"
+           "+COLOR-TABLE-RED-SIZE-EXT+"
+           "+COLOR-TABLE-GREEN-SIZE-EXT+"
+           "+COLOR-TABLE-BLUE-SIZE-EXT+"
+           "+COLOR-TABLE-ALPHA-SIZE-EXT+"
+           "+COLOR-TABLE-LUMINANCE-SIZE-EXT+"
+           "+COLOR-TABLE-INTENSITY-SIZE-EXT+"
+           "+TEXTURE-INDEX-SIZE-EXT+"
+           "+COLOR-INDEX1-EXT+"
+           "+COLOR-INDEX2-EXT+"
+           "+COLOR-INDEX4-EXT+"
+           "+COLOR-INDEX8-EXT+"
+           "+COLOR-INDEX12-EXT+"
+           "+COLOR-INDEX16-EXT+"
+           "+EXT-CLIP-VOLUME-HINT+"
+           "+CLIP-VOLUME-CLIPPING-HINT-EXT+"
+           "+EXT-COMPILED-VERTEX-ARRAY+"
+           "+ARRAY-ELEMENT-LOCK-FIRST-EXT+"
+           "+ARRAY-ELEMENT-LOCK-COUNT-EXT+"
+           "+HP-OCCLUSION-TEST+"
+           "+OCCLUSION-TEST-HP+"
+           "+OCCLUSION-TEST-RESULT-HP+"
+           "+EXT-SHARED-TEXTURE-PALETTE+"
+           "+SHARED-TEXTURE-PALETTE-EXT+"
+           "+EXT-STENCIL-WRAP+"
+           "+INCR-WRAP-EXT+"
+           "+DECR-WRAP-EXT+"
+           "+NV-TEXGEN-REFLECTION+"
+           "+NORMAL-MAP-NV+"
+           "+REFLECTION-MAP-NV+"
+           "+EXT-TEXTURE-ENV-ADD+"
+           "+MESA-WINDOW-POS+"
+           "+MESA-RESIZE-BUFFERS+"
+           
+           ))
+
+
+(in-package :gl)
+
+
+
+;;; Opcodes.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defconstant +get-string+       129)
+(defconstant +new-list+         101)
+(defconstant +end-list+         102)
+(defconstant +gen-lists+        104)
+(defconstant +finish+           108)
+(defconstant +disable+          138)
+(defconstant +enable+           139)
+(defconstant +flush+            142)
+
+
+
+;;; Constants.
+;;; Shamelessly taken from CL-SDL.
+
+;; Boolean
+
+(defconstant +false+                            #x0) 
+(defconstant +true+                             #x1) 
+
+;; Types
+
+(defconstant +byte+                          #x1400) 
+(defconstant +unsigned-byte+                 #x1401) 
+(defconstant +short+                         #x1402) 
+(defconstant +unsigned-short+                #x1403) 
+(defconstant +int+                           #x1404) 
+(defconstant +unsigned-int+                  #x1405) 
+(defconstant +float+                         #x1406) 
+(defconstant +double+                        #x140a) 
+(defconstant +2-bytes+                       #x1407) 
+(defconstant +3-bytes+                       #x1408) 
+(defconstant +4-bytes+                       #x1409) 
+
+;; Primitives
+
+(defconstant +points+                        #x0000) 
+(defconstant +lines+                         #x0001) 
+(defconstant +line-loop+                     #x0002) 
+(defconstant +line-strip+                    #x0003) 
+(defconstant +triangles+                     #x0004) 
+(defconstant +triangle-strip+                #x0005) 
+(defconstant +triangle-fan+                  #x0006) 
+(defconstant +quads+                         #x0007) 
+(defconstant +quad-strip+                    #x0008) 
+(defconstant +polygon+                       #x0009) 
+
+;; Arrays
+
+(defconstant +vertex-array+                  #x8074) 
+(defconstant +normal-array+                  #x8075) 
+(defconstant +color-array+                   #x8076) 
+(defconstant +index-array+                   #x8077) 
+(defconstant +texture-coord-array+           #x8078) 
+(defconstant +edge-flag-array+               #x8079) 
+(defconstant +vertex-array-size+             #x807a) 
+(defconstant +vertex-array-type+             #x807b) 
+(defconstant +vertex-array-stride+           #x807c) 
+(defconstant +normal-array-type+             #x807e) 
+(defconstant +normal-array-stride+           #x807f) 
+(defconstant +color-array-size+              #x8081) 
+(defconstant +color-array-type+              #x8082) 
+(defconstant +color-array-stride+            #x8083) 
+(defconstant +index-array-type+              #x8085) 
+(defconstant +index-array-stride+            #x8086) 
+(defconstant +texture-coord-array-size+      #x8088) 
+(defconstant +texture-coord-array-type+      #x8089) 
+(defconstant +texture-coord-array-stride+    #x808a) 
+(defconstant +edge-flag-array-stride+        #x808c) 
+(defconstant +vertex-array-pointer+          #x808e) 
+(defconstant +normal-array-pointer+          #x808f) 
+(defconstant +color-array-pointer+           #x8090) 
+(defconstant +index-array-pointer+           #x8091) 
+(defconstant +texture-coord-array-pointer+   #x8092) 
+(defconstant +edge-flag-array-pointer+       #x8093) 
+
+;; Array formats
+
+(defconstant +v2f+                           #x2a20) 
+(defconstant +v3f+                           #x2a21) 
+(defconstant +c4ub-v2f+                      #x2a22) 
+(defconstant +c4ub-v3f+                      #x2a23) 
+(defconstant +c3f-v3f+                       #x2a24) 
+(defconstant +n3f-v3f+                       #x2a25) 
+(defconstant +c4f-n3f-v3f+                   #x2a26) 
+(defconstant +t2f-v3f+                       #x2a27) 
+(defconstant +t4f-v4f+                       #x2a28) 
+(defconstant +t2f-c4ub-v3f+                  #x2a29) 
+(defconstant +t2f-c3f-v3f+                   #x2a2a) 
+(defconstant +t2f-n3f-v3f+                   #x2a2b) 
+(defconstant +t2f-c4f-n3f-v3f+               #x2a2c) 
+(defconstant +t4f-c4f-n3f-v4f+               #x2a2d) 
+
+;; Matrices
+
+(defconstant +matrix-mode+                   #x0ba0) 
+(defconstant +modelview+                     #x1700) 
+(defconstant +projection+                    #x1701) 
+(defconstant +texture+                       #x1702) 
+
+;; Points
+
+(defconstant +point-smooth+                  #x0b10) 
+(defconstant +point-size+                    #x0b11) 
+(defconstant +point-size-granularity+        #x0b13) 
+(defconstant +point-size-range+              #x0b12) 
+
+;; Lines
+
+(defconstant +line-smooth+                   #x0b20) 
+(defconstant +line-stipple+                  #x0b24) 
+(defconstant +line-stipple-pattern+          #x0b25) 
+(defconstant +line-stipple-repeat+           #x0b26) 
+(defconstant +line-width+                    #x0b21) 
+(defconstant +line-width-granularity+        #x0b23) 
+(defconstant +line-width-range+              #x0b22) 
+
+;; Polygons
+
+(defconstant +point+                         #x1b00) 
+(defconstant +line+                          #x1b01) 
+(defconstant +fill+                          #x1b02) 
+(defconstant +cw+                            #x0900) 
+(defconstant +ccw+                           #x0901) 
+(defconstant +front+                         #x0404) 
+(defconstant +back+                          #x0405) 
+(defconstant +polygon-mode+                  #x0b40) 
+(defconstant +polygon-smooth+                #x0b41) 
+(defconstant +polygon-stipple+               #x0b42) 
+(defconstant +edge-flag+                     #x0b43) 
+(defconstant +cull-face+                     #x0b44) 
+(defconstant +cull-face-mode+                #x0b45) 
+(defconstant +front-face+                    #x0b46) 
+(defconstant +polygon-offset-factor+         #x8038) 
+(defconstant +polygon-offset-units+          #x2a00) 
+(defconstant +polygon-offset-point+          #x2a01) 
+(defconstant +polygon-offset-line+           #x2a02) 
+(defconstant +polygon-offset-fill+           #x8037) 
+
+;; Display Lists
+
+(defconstant +compile+                       #x1300) 
+(defconstant +compile-and-execute+           #x1301) 
+(defconstant +list-base+                     #x0b32) 
+(defconstant +list-index+                    #x0b33) 
+(defconstant +list-mode+                     #x0b30) 
+
+;; Depth Buffer
+
+(defconstant +never+                         #x0200) 
+(defconstant +less+                          #x0201) 
+(defconstant +equal+                         #x0202) 
+(defconstant +lequal+                        #x0203) 
+(defconstant +greater+                       #x0204) 
+(defconstant +notequal+                      #x0205) 
+(defconstant +gequal+                        #x0206) 
+(defconstant +always+                        #x0207) 
+(defconstant +depth-test+                    #x0b71) 
+(defconstant +depth-bits+                    #x0d56) 
+(defconstant +depth-clear-value+             #x0b73) 
+(defconstant +depth-func+                    #x0b74) 
+(defconstant +depth-range+                   #x0b70) 
+(defconstant +depth-writemask+               #x0b72) 
+(defconstant +depth-component+               #x1902) 
+
+;; Lighting
+
+(defconstant +lighting+                      #x0b50) 
+(defconstant +light0+                        #x4000) 
+(defconstant +light1+                        #x4001) 
+(defconstant +light2+                        #x4002) 
+(defconstant +light3+                        #x4003) 
+(defconstant +light4+                        #x4004) 
+(defconstant +light5+                        #x4005) 
+(defconstant +light6+                        #x4006) 
+(defconstant +light7+                        #x4007) 
+(defconstant +spot-exponent+                 #x1205) 
+(defconstant +spot-cutoff+                   #x1206) 
+(defconstant +constant-attenuation+          #x1207) 
+(defconstant +linear-attenuation+            #x1208) 
+(defconstant +quadratic-attenuation+         #x1209) 
+(defconstant +ambient+                       #x1200) 
+(defconstant +diffuse+                       #x1201) 
+(defconstant +specular+                      #x1202) 
+(defconstant +shininess+                     #x1601) 
+(defconstant +emission+                      #x1600) 
+(defconstant +position+                      #x1203) 
+(defconstant +spot-direction+                #x1204) 
+(defconstant +ambient-and-diffuse+           #x1602) 
+(defconstant +color-indexes+                 #x1603) 
+(defconstant +light-model-two-side+          #x0b52) 
+(defconstant +light-model-local-viewer+      #x0b51) 
+(defconstant +light-model-ambient+           #x0b53) 
+(defconstant +front-and-back+                #x0408) 
+(defconstant +shade-model+                   #x0b54) 
+(defconstant +flat+                          #x1d00) 
+(defconstant +smooth+                        #x1d01) 
+(defconstant +color-material+                #x0b57) 
+(defconstant +color-material-face+           #x0b55) 
+(defconstant +color-material-parameter+      #x0b56) 
+(defconstant +normalize+                     #x0ba1) 
+
+;; Clipping planes
+
+(defconstant +clip-plane0+                   #x3000) 
+(defconstant +clip-plane1+                   #x3001) 
+(defconstant +clip-plane2+                   #x3002) 
+(defconstant +clip-plane3+                   #x3003) 
+(defconstant +clip-plane4+                   #x3004) 
+(defconstant +clip-plane5+                   #x3005) 
+
+;; Accumulation buffer
+
+(defconstant +accum-red-bits+                #x0d58) 
+(defconstant +accum-green-bits+              #x0d59) 
+(defconstant +accum-blue-bits+               #x0d5a) 
+(defconstant +accum-alpha-bits+              #x0d5b) 
+(defconstant +accum-clear-value+             #x0b80) 
+(defconstant +accum+                         #x0100) 
+(defconstant +add+                           #x0104) 
+(defconstant +load+                          #x0101) 
+(defconstant +mult+                          #x0103) 
+(defconstant +return+                        #x0102) 
+
+;; Alpha Testing
+
+(defconstant +alpha-test+                    #x0bc0) 
+(defconstant +alpha-test-ref+                #x0bc2) 
+(defconstant +alpha-test-func+               #x0bc1) 
+
+;; Blending
+
+(defconstant +blend+                         #x0be2) 
+(defconstant +blend-src+                     #x0be1) 
+(defconstant +blend-dst+                     #x0be0) 
+(defconstant +zero+                             #x0) 
+(defconstant +one+                              #x1) 
+(defconstant +src-color+                     #x0300) 
+(defconstant +one-minus-src-color+           #x0301) 
+(defconstant +dst-color+                     #x0306) 
+(defconstant +one-minus-dst-color+           #x0307) 
+(defconstant +src-alpha+                     #x0302) 
+(defconstant +one-minus-src-alpha+           #x0303) 
+(defconstant +dst-alpha+                     #x0304) 
+(defconstant +one-minus-dst-alpha+           #x0305) 
+(defconstant +src-alpha-saturate+            #x0308) 
+(defconstant +constant-color+                #x8001) 
+(defconstant +one-minus-constant-color+      #x8002) 
+(defconstant +constant-alpha+                #x8003) 
+(defconstant +one-minus-constant-alpha+      #x8004) 
+
+;; Render mode
+
+(defconstant +feedback+                      #x1c01) 
+(defconstant +render+                        #x1c00) 
+(defconstant +select+                        #x1c02) 
+
+;; Feedback
+
+(defconstant +2d+                            #x0600) 
+(defconstant +3d+                            #x0601) 
+(defconstant +3d-color+                      #x0602) 
+(defconstant +3d-color-texture+              #x0603) 
+(defconstant +4d-color-texture+              #x0604) 
+(defconstant +point-token+                   #x0701) 
+(defconstant +line-token+                    #x0702) 
+(defconstant +line-reset-token+              #x0707) 
+(defconstant +polygon-token+                 #x0703) 
+(defconstant +bitmap-token+                  #x0704) 
+(defconstant +draw-pixel-token+              #x0705) 
+(defconstant +copy-pixel-token+              #x0706) 
+(defconstant +pass-through-token+            #x0700) 
+(defconstant +feedback-buffer-pointer+       #x0df0) 
+(defconstant +feedback-buffer-size+          #x0df1) 
+(defconstant +feedback-buffer-type+          #x0df2) 
+
+;; Selection
+
+(defconstant +selection-buffer-pointer+      #x0df3) 
+(defconstant +selection-buffer-size+         #x0df4) 
+
+;; Fog
+
+(defconstant +fog+                           #x0b60) 
+(defconstant +fog-mode+                      #x0b65) 
+(defconstant +fog-density+                   #x0b62) 
+(defconstant +fog-color+                     #x0b66) 
+(defconstant +fog-index+                     #x0b61) 
+(defconstant +fog-start+                     #x0b63) 
+(defconstant +fog-end+                       #x0b64) 
+(defconstant +linear+                        #x2601) 
+(defconstant +exp+                           #x0800) 
+(defconstant +exp2+                          #x0801) 
+
+;; Logic operations
+
+(defconstant +logic-op+                      #x0bf1) 
+(defconstant +index-logic-op+                #x0bf1) 
+(defconstant +color-logic-op+                #x0bf2) 
+(defconstant +logic-op-mode+                 #x0bf0) 
+(defconstant +clear+                         #x1500) 
+(defconstant +set+                           #x150f) 
+(defconstant +copy+                          #x1503) 
+(defconstant +copy-inverted+                 #x150c) 
+(defconstant +noop+                          #x1505) 
+(defconstant +invert+                        #x150a) 
+(defconstant +and+                           #x1501) 
+(defconstant +nand+                          #x150e) 
+(defconstant +or+                            #x1507) 
+(defconstant +nor+                           #x1508) 
+(defconstant +xor+                           #x1506) 
+(defconstant +equiv+                         #x1509) 
+(defconstant +and-reverse+                   #x1502) 
+(defconstant +and-inverted+                  #x1504) 
+(defconstant +or-reverse+                    #x150b) 
+(defconstant +or-inverted+                   #x150d) 
+
+;; Stencil
+
+(defconstant +stencil-test+                  #x0b90) 
+(defconstant +stencil-writemask+             #x0b98) 
+(defconstant +stencil-bits+                  #x0d57) 
+(defconstant +stencil-func+                  #x0b92) 
+(defconstant +stencil-value-mask+            #x0b93) 
+(defconstant +stencil-ref+                   #x0b97) 
+(defconstant +stencil-fail+                  #x0b94) 
+(defconstant +stencil-pass-depth-pass+       #x0b96) 
+(defconstant +stencil-pass-depth-fail+       #x0b95) 
+(defconstant +stencil-clear-value+           #x0b91) 
+(defconstant +stencil-index+                 #x1901) 
+(defconstant +keep+                          #x1e00) 
+(defconstant +replace+                       #x1e01) 
+(defconstant +incr+                          #x1e02) 
+(defconstant +decr+                          #x1e03) 
+
+;; Buffers, Pixel Drawing/Reading
+
+(defconstant +none+                             #x0) 
+(defconstant +left+                          #x0406) 
+(defconstant +right+                         #x0407) 
+(defconstant +front-left+                    #x0400) 
+(defconstant +front-right+                   #x0401) 
+(defconstant +back-left+                     #x0402) 
+(defconstant +back-right+                    #x0403) 
+(defconstant +aux0+                          #x0409) 
+(defconstant +aux1+                          #x040a) 
+(defconstant +aux2+                          #x040b) 
+(defconstant +aux3+                          #x040c) 
+(defconstant +color-index+                   #x1900) 
+(defconstant +red+                           #x1903) 
+(defconstant +green+                         #x1904) 
+(defconstant +blue+                          #x1905) 
+(defconstant +alpha+                         #x1906) 
+(defconstant +luminance+                     #x1909) 
+(defconstant +luminance-alpha+               #x190a) 
+(defconstant +alpha-bits+                    #x0d55) 
+(defconstant +red-bits+                      #x0d52) 
+(defconstant +green-bits+                    #x0d53) 
+(defconstant +blue-bits+                     #x0d54) 
+(defconstant +index-bits+                    #x0d51) 
+(defconstant +subpixel-bits+                 #x0d50) 
+(defconstant +aux-buffers+                   #x0c00) 
+(defconstant +read-buffer+                   #x0c02) 
+(defconstant +draw-buffer+                   #x0c01) 
+(defconstant +doublebuffer+                  #x0c32) 
+(defconstant +stereo+                        #x0c33) 
+(defconstant +bitmap+                        #x1a00) 
+(defconstant +color+                         #x1800) 
+(defconstant +depth+                         #x1801) 
+(defconstant +stencil+                       #x1802) 
+(defconstant +dither+                        #x0bd0) 
+(defconstant +rgb+                           #x1907) 
+(defconstant +rgba+                          #x1908) 
+
+;; Implementation Limits
+
+(defconstant +max-list-nesting+              #x0b31) 
+(defconstant +max-attrib-stack-depth+        #x0d35) 
+(defconstant +max-modelview-stack-depth+     #x0d36) 
+(defconstant +max-name-stack-depth+          #x0d37) 
+(defconstant +max-projection-stack-depth+    #x0d38) 
+(defconstant +max-texture-stack-depth+       #x0d39) 
+(defconstant +max-eval-order+                #x0d30) 
+(defconstant +max-lights+                    #x0d31) 
+(defconstant +max-clip-planes+               #x0d32) 
+(defconstant +max-texture-size+              #x0d33) 
+(defconstant +max-pixel-map-table+           #x0d34) 
+(defconstant +max-viewport-dims+             #x0d3a) 
+(defconstant +max-client-attrib-stack-depth+ #x0d3b) 
+
+;; Gets
+
+(defconstant +attrib-stack-depth+            #x0bb0) 
+(defconstant +client-attrib-stack-depth+     #x0bb1) 
+(defconstant +color-clear-value+             #x0c22) 
+(defconstant +color-writemask+               #x0c23) 
+(defconstant +current-index+                 #x0b01) 
+(defconstant +current-color+                 #x0b00) 
+(defconstant +current-normal+                #x0b02) 
+(defconstant +current-raster-color+          #x0b04) 
+(defconstant +current-raster-distance+       #x0b09) 
+(defconstant +current-raster-index+          #x0b05) 
+(defconstant +current-raster-position+       #x0b07) 
+(defconstant +current-raster-texture-coords+ #x0b06) 
+(defconstant +current-raster-position-valid+ #x0b08) 
+(defconstant +current-texture-coords+        #x0b03) 
+(defconstant +index-clear-value+             #x0c20) 
+(defconstant +index-mode+                    #x0c30) 
+(defconstant +index-writemask+               #x0c21) 
+(defconstant +modelview-matrix+              #x0ba6) 
+(defconstant +modelview-stack-depth+         #x0ba3) 
+(defconstant +name-stack-depth+              #x0d70) 
+(defconstant +projection-matrix+             #x0ba7) 
+(defconstant +projection-stack-depth+        #x0ba4) 
+(defconstant +render-mode+                   #x0c40) 
+(defconstant +rgba-mode+                     #x0c31) 
+(defconstant +texture-matrix+                #x0ba8) 
+(defconstant +texture-stack-depth+           #x0ba5) 
+(defconstant +viewport+                      #x0ba2) 
+
+;; GL Evaluators
+
+(defconstant +auto-normal+                   #x0d80) 
+(defconstant +map1-color-4+                  #x0d90) 
+(defconstant +map1-grid-domain+              #x0dd0) 
+(defconstant +map1-grid-segments+            #x0dd1) 
+(defconstant +map1-index+                    #x0d91) 
+(defconstant +map1-normal+                   #x0d92) 
+(defconstant +map1-texture-coord-1+          #x0d93) 
+(defconstant +map1-texture-coord-2+          #x0d94) 
+(defconstant +map1-texture-coord-3+          #x0d95) 
+(defconstant +map1-texture-coord-4+          #x0d96) 
+(defconstant +map1-vertex-3+                 #x0d97) 
+(defconstant +map1-vertex-4+                 #x0d98) 
+(defconstant +map2-color-4+                  #x0db0) 
+(defconstant +map2-grid-domain+              #x0dd2) 
+(defconstant +map2-grid-segments+            #x0dd3) 
+(defconstant +map2-index+                    #x0db1) 
+(defconstant +map2-normal+                   #x0db2) 
+(defconstant +map2-texture-coord-1+          #x0db3) 
+(defconstant +map2-texture-coord-2+          #x0db4) 
+(defconstant +map2-texture-coord-3+          #x0db5) 
+(defconstant +map2-texture-coord-4+          #x0db6) 
+(defconstant +map2-vertex-3+                 #x0db7) 
+(defconstant +map2-vertex-4+                 #x0db8) 
+(defconstant +coeff+                         #x0a00) 
+(defconstant +domain+                        #x0a02) 
+(defconstant +order+                         #x0a01) 
+
+;; Hints
+
+(defconstant +fog-hint+                      #x0c54) 
+(defconstant +line-smooth-hint+              #x0c52) 
+(defconstant +perspective-correction-hint+   #x0c50) 
+(defconstant +point-smooth-hint+             #x0c51) 
+(defconstant +polygon-smooth-hint+           #x0c53) 
+(defconstant +dont-care+                     #x1100) 
+(defconstant +fastest+                       #x1101) 
+(defconstant +nicest+                        #x1102) 
+
+;; Scissor box
+
+(defconstant +scissor-test+                  #x0c11) 
+(defconstant +scissor-box+                   #x0c10) 
+
+;; Pixel Mode / Transfer
+
+(defconstant +map-color+                     #x0d10) 
+(defconstant +map-stencil+                   #x0d11) 
+(defconstant +index-shift+                   #x0d12) 
+(defconstant +index-offset+                  #x0d13) 
+(defconstant +red-scale+                     #x0d14) 
+(defconstant +red-bias+                      #x0d15) 
+(defconstant +green-scale+                   #x0d18) 
+(defconstant +green-bias+                    #x0d19) 
+(defconstant +blue-scale+                    #x0d1a) 
+(defconstant +blue-bias+                     #x0d1b) 
+(defconstant +alpha-scale+                   #x0d1c) 
+(defconstant +alpha-bias+                    #x0d1d) 
+(defconstant +depth-scale+                   #x0d1e) 
+(defconstant +depth-bias+                    #x0d1f) 
+(defconstant +pixel-map-s-to-s-size+         #x0cb1) 
+(defconstant +pixel-map-i-to-i-size+         #x0cb0) 
+(defconstant +pixel-map-i-to-r-size+         #x0cb2) 
+(defconstant +pixel-map-i-to-g-size+         #x0cb3) 
+(defconstant +pixel-map-i-to-b-size+         #x0cb4) 
+(defconstant +pixel-map-i-to-a-size+         #x0cb5) 
+(defconstant +pixel-map-r-to-r-size+         #x0cb6) 
+(defconstant +pixel-map-g-to-g-size+         #x0cb7) 
+(defconstant +pixel-map-b-to-b-size+         #x0cb8) 
+(defconstant +pixel-map-a-to-a-size+         #x0cb9) 
+(defconstant +pixel-map-s-to-s+              #x0c71) 
+(defconstant +pixel-map-i-to-i+              #x0c70) 
+(defconstant +pixel-map-i-to-r+              #x0c72) 
+(defconstant +pixel-map-i-to-g+              #x0c73) 
+(defconstant +pixel-map-i-to-b+              #x0c74) 
+(defconstant +pixel-map-i-to-a+              #x0c75) 
+(defconstant +pixel-map-r-to-r+              #x0c76) 
+(defconstant +pixel-map-g-to-g+              #x0c77) 
+(defconstant +pixel-map-b-to-b+              #x0c78) 
+(defconstant +pixel-map-a-to-a+              #x0c79) 
+(defconstant +pack-alignment+                #x0d05) 
+(defconstant +pack-lsb-first+                #x0d01) 
+(defconstant +pack-row-length+               #x0d02) 
+(defconstant +pack-skip-pixels+              #x0d04) 
+(defconstant +pack-skip-rows+                #x0d03) 
+(defconstant +pack-swap-bytes+               #x0d00) 
+(defconstant +unpack-alignment+              #x0cf5) 
+(defconstant +unpack-lsb-first+              #x0cf1) 
+(defconstant +unpack-row-length+             #x0cf2) 
+(defconstant +unpack-skip-pixels+            #x0cf4) 
+(defconstant +unpack-skip-rows+              #x0cf3) 
+(defconstant +unpack-swap-bytes+             #x0cf0) 
+(defconstant +zoom-x+                        #x0d16) 
+(defconstant +zoom-y+                        #x0d17) 
+
+;; Texture Mapping
+
+(defconstant +texture-env+                   #x2300) 
+(defconstant +texture-env-mode+              #x2200) 
+(defconstant +texture-1d+                    #x0de0) 
+(defconstant +texture-2d+                    #x0de1) 
+(defconstant +texture-wrap-s+                #x2802) 
+(defconstant +texture-wrap-t+                #x2803) 
+(defconstant +texture-mag-filter+            #x2800) 
+(defconstant +texture-min-filter+            #x2801) 
+(defconstant +texture-env-color+             #x2201) 
+(defconstant +texture-gen-s+                 #x0c60) 
+(defconstant +texture-gen-t+                 #x0c61) 
+(defconstant +texture-gen-mode+              #x2500) 
+(defconstant +texture-border-color+          #x1004) 
+(defconstant +texture-width+                 #x1000) 
+(defconstant +texture-height+                #x1001) 
+(defconstant +texture-border+                #x1005) 
+(defconstant +texture-components+            #x1003) 
+(defconstant +texture-red-size+              #x805c) 
+(defconstant +texture-green-size+            #x805d) 
+(defconstant +texture-blue-size+             #x805e) 
+(defconstant +texture-alpha-size+            #x805f) 
+(defconstant +texture-luminance-size+        #x8060) 
+(defconstant +texture-intensity-size+        #x8061) 
+(defconstant +nearest-mipmap-nearest+        #x2700) 
+(defconstant +nearest-mipmap-linear+         #x2702) 
+(defconstant +linear-mipmap-nearest+         #x2701) 
+(defconstant +linear-mipmap-linear+          #x2703) 
+(defconstant +object-linear+                 #x2401) 
+(defconstant +object-plane+                  #x2501) 
+(defconstant +eye-linear+                    #x2400) 
+(defconstant +eye-plane+                     #x2502) 
+(defconstant +sphere-map+                    #x2402) 
+(defconstant +decal+                         #x2101) 
+(defconstant +modulate+                      #x2100) 
+(defconstant +nearest+                       #x2600) 
+(defconstant +repeat+                        #x2901) 
+(defconstant +clamp+                         #x2900) 
+(defconstant +s+                             #x2000) 
+(defconstant +t+                             #x2001) 
+(defconstant +r+                             #x2002) 
+(defconstant +q+                             #x2003) 
+(defconstant +texture-gen-r+                 #x0c62) 
+(defconstant +texture-gen-q+                 #x0c63) 
+
+;; GL 1.1 Texturing
+
+(defconstant +proxy-texture-1d+              #x8063) 
+(defconstant +proxy-texture-2d+              #x8064) 
+(defconstant +texture-priority+              #x8066) 
+(defconstant +texture-resident+              #x8067) 
+(defconstant +texture-binding-1d+            #x8068) 
+(defconstant +texture-binding-2d+            #x8069) 
+(defconstant +texture-internal-format+       #x1003) 
+(defconstant +pack-skip-images+              #x806b) 
+(defconstant +pack-image-height+             #x806c) 
+(defconstant +unpack-skip-images+            #x806d) 
+(defconstant +unpack-image-height+           #x806e) 
+(defconstant +texture-3d+                    #x806f) 
+(defconstant +proxy-texture-3d+              #x8070) 
+(defconstant +texture-depth+                 #x8071) 
+(defconstant +texture-wrap-r+                #x8072) 
+(defconstant +max-3d-texture-size+           #x8073) 
+(defconstant +texture-binding-3d+            #x806a) 
+
+;; Internal texture formats (GL 1.1)
+(defconstant +alpha4+                        #x803b) 
+(defconstant +alpha8+                        #x803c) 
+(defconstant +alpha12+                       #x803d) 
+(defconstant +alpha16+                       #x803e) 
+(defconstant +luminance4+                    #x803f) 
+(defconstant +luminance8+                    #x8040) 
+(defconstant +luminance12+                   #x8041) 
+(defconstant +luminance16+                   #x8042) 
+(defconstant +luminance4-alpha4+             #x8043) 
+(defconstant +luminance6-alpha2+             #x8044) 
+(defconstant +luminance8-alpha8+             #x8045) 
+(defconstant +luminance12-alpha4+            #x8046) 
+(defconstant +luminance12-alpha12+           #x8047) 
+(defconstant +luminance16-alpha16+           #x8048) 
+(defconstant +intensity+                     #x8049) 
+(defconstant +intensity4+                    #x804a) 
+(defconstant +intensity8+                    #x804b) 
+(defconstant +intensity12+                   #x804c) 
+(defconstant +intensity16+                   #x804d) 
+(defconstant +r3-g3-b2+                      #x2a10) 
+(defconstant +rgb4+                          #x804f) 
+(defconstant +rgb5+                          #x8050) 
+(defconstant +rgb8+                          #x8051) 
+(defconstant +rgb10+                         #x8052) 
+(defconstant +rgb12+                         #x8053) 
+(defconstant +rgb16+                         #x8054) 
+(defconstant +rgba2+                         #x8055) 
+(defconstant +rgba4+                         #x8056) 
+(defconstant +rgb5-a1+                       #x8057) 
+(defconstant +rgba8+                         #x8058) 
+(defconstant +rgb10-a2+                      #x8059) 
+(defconstant +rgba12+                        #x805a) 
+(defconstant +rgba16+                        #x805b) 
+
+;; Utility
+
+(defconstant +vendor+                        #x1f00) 
+(defconstant +renderer+                      #x1f01) 
+(defconstant +version+                       #x1f02) 
+(defconstant +extensions+                    #x1f03) 
+
+;; Errors
+
+(defconstant +no-error+                         #x0) 
+(defconstant +invalid-value+                 #x0501) 
+(defconstant +invalid-enum+                  #x0500) 
+(defconstant +invalid-operation+             #x0502) 
+(defconstant +stack-overflow+                #x0503) 
+(defconstant +stack-underflow+               #x0504) 
+(defconstant +out-of-memory+                 #x0505) 
+
+;; OpenGL 1.2
+
+(defconstant +rescale-normal+                #x803a) 
+(defconstant +clamp-to-edge+                 #x812f) 
+(defconstant +max-elements-vertices+         #x80e8) 
+(defconstant +max-elements-indices+          #x80e9) 
+(defconstant +bgr+                           #x80e0) 
+(defconstant +bgra+                          #x80e1) 
+(defconstant +unsigned-byte-3-3-2+           #x8032) 
+(defconstant +unsigned-byte-2-3-3-rev+       #x8362) 
+(defconstant +unsigned-short-5-6-5+          #x8363) 
+(defconstant +unsigned-short-5-6-5-rev+      #x8364) 
+(defconstant +unsigned-short-4-4-4-4+        #x8033) 
+(defconstant +unsigned-short-4-4-4-4-rev+    #x8365) 
+(defconstant +unsigned-short-5-5-5-1+        #x8034) 
+(defconstant +unsigned-short-1-5-5-5-rev+    #x8366) 
+(defconstant +unsigned-int-8-8-8-8+          #x8035) 
+(defconstant +unsigned-int-8-8-8-8-rev+      #x8367) 
+(defconstant +unsigned-int-10-10-10-2+       #x8036) 
+(defconstant +unsigned-int-2-10-10-10-rev+   #x8368) 
+(defconstant +light-model-color-control+     #x81f8) 
+(defconstant +single-color+                  #x81f9) 
+(defconstant +separate-specular-color+       #x81fa) 
+(defconstant +texture-min-lod+               #x813a) 
+(defconstant +texture-max-lod+               #x813b) 
+(defconstant +texture-base-level+            #x813c) 
+(defconstant +texture-max-level+             #x813d) 
+(defconstant +smooth-point-size-range+       #x0b12) 
+(defconstant +smooth-point-size-granularity+ #x0b13) 
+(defconstant +smooth-line-width-range+       #x0b22) 
+(defconstant +smooth-line-width-granularity+ #x0b23) 
+(defconstant +aliased-point-size-range+      #x846d) 
+(defconstant +aliased-line-width-range+      #x846e) 
+
+;; OpenGL 1.2 Imaging subset
+;; GL_EXT_color_table
+(defconstant +color-table+                   #x80d0) 
+(defconstant +post-convolution-color-table+  #x80d1) 
+(defconstant +post-color-matrix-color-table+ #x80d2) 
+(defconstant +proxy-color-table+             #x80d3) 
+(defconstant +proxy-post-convolution-color-table+  #x80d4) 
+(defconstant +proxy-post-color-matrix-color-table+ #x80d5) 
+(defconstant +color-table-scale+             #x80d6) 
+(defconstant +color-table-bias+              #x80d7) 
+(defconstant +color-table-format+            #x80d8) 
+(defconstant +color-table-width+             #x80d9) 
+(defconstant +color-table-red-size+          #x80da) 
+(defconstant +color-table-green-size+        #x80db) 
+(defconstant +color-table-blue-size+         #x80dc) 
+(defconstant +color-table-alpha-size+        #x80dd) 
+(defconstant +color-table-luminance-size+    #x80de) 
+(defconstant +color-table-intensity-size+    #x80df) 
+;; GL_EXT_convolution and GL_HP_convolution
+(defconstant +convolution-1d+                #x8010) 
+(defconstant +convolution-2d+                #x8011) 
+(defconstant +separable-2d+                  #x8012) 
+(defconstant +convolution-border-mode+       #x8013) 
+(defconstant +convolution-filter-scale+      #x8014) 
+(defconstant +convolution-filter-bias+       #x8015) 
+(defconstant +reduce+                        #x8016) 
+(defconstant +convolution-format+            #x8017) 
+(defconstant +convolution-width+             #x8018) 
+(defconstant +convolution-height+            #x8019) 
+(defconstant +max-convolution-width+         #x801a) 
+(defconstant +max-convolution-height+        #x801b) 
+(defconstant +post-convolution-red-scale+    #x801c) 
+(defconstant +post-convolution-green-scale+  #x801d) 
+(defconstant +post-convolution-blue-scale+   #x801e) 
+(defconstant +post-convolution-alpha-scale+  #x801f) 
+(defconstant +post-convolution-red-bias+     #x8020) 
+(defconstant +post-convolution-green-bias+   #x8021) 
+(defconstant +post-convolution-blue-bias+    #x8022) 
+(defconstant +post-convolution-alpha-bias+   #x8023) 
+(defconstant +constant-border+               #x8151) 
+(defconstant +replicate-border+              #x8153) 
+(defconstant +convolution-border-color+      #x8154) 
+;; GL_SGI_color_matrix
+(defconstant +color-matrix+                  #x80b1) 
+(defconstant +color-matrix-stack-depth+      #x80b2) 
+(defconstant +max-color-matrix-stack-depth+  #x80b3) 
+(defconstant +post-color-matrix-red-scale+   #x80b4) 
+(defconstant +post-color-matrix-green-scale+ #x80b5) 
+(defconstant +post-color-matrix-blue-scale+  #x80b6) 
+(defconstant +post-color-matrix-alpha-scale+ #x80b7) 
+(defconstant +post-color-matrix-red-bias+    #x80b8) 
+(defconstant +post-color-matrix-green-bias+  #x80b9) 
+(defconstant +post-color-matrix-blue-bias+   #x80ba) 
+(defconstant +post-color-matrix-alpha-bias+  #x80bb) 
+;; GL_EXT_histogram
+(defconstant +histogram+                     #x8024) 
+(defconstant +proxy-histogram+               #x8025) 
+(defconstant +histogram-width+               #x8026) 
+(defconstant +histogram-format+              #x8027) 
+(defconstant +histogram-red-size+            #x8028) 
+(defconstant +histogram-green-size+          #x8029) 
+(defconstant +histogram-blue-size+           #x802a) 
+(defconstant +histogram-alpha-size+          #x802b) 
+(defconstant +histogram-luminance-size+      #x802c) 
+(defconstant +histogram-sink+                #x802d) 
+(defconstant +minmax+                        #x802e) 
+(defconstant +minmax-format+                 #x802f) 
+(defconstant +minmax-sink+                   #x8030) 
+(defconstant +table-too-large+               #x8031) 
+;; GL_EXT_blend_color, GL_EXT_blend_minmax
+(defconstant +blend-equation+                #x8009) 
+(defconstant +min+                           #x8007) 
+(defconstant +max+                           #x8008) 
+(defconstant +func-add+                      #x8006) 
+(defconstant +func-subtract+                 #x800a) 
+(defconstant +func-reverse-subtract+         #x800b) 
+
+;; glPush/PopAttrib bits
+
+(defconstant +current-bit+               #x00000001) 
+(defconstant +point-bit+                 #x00000002) 
+(defconstant +line-bit+                  #x00000004) 
+(defconstant +polygon-bit+               #x00000008) 
+(defconstant +polygon-stipple-bit+       #x00000010) 
+(defconstant +pixel-mode-bit+            #x00000020) 
+(defconstant +lighting-bit+              #x00000040) 
+(defconstant +fog-bit+                   #x00000080) 
+(defconstant +depth-buffer-bit+          #x00000100) 
+(defconstant +accum-buffer-bit+          #x00000200) 
+(defconstant +stencil-buffer-bit+        #x00000400) 
+(defconstant +viewport-bit+              #x00000800) 
+(defconstant +transform-bit+             #x00001000) 
+(defconstant +enable-bit+                #x00002000) 
+(defconstant +color-buffer-bit+          #x00004000) 
+(defconstant +hint-bit+                  #x00008000) 
+(defconstant +eval-bit+                  #x00010000) 
+(defconstant +list-bit+                  #x00020000) 
+(defconstant +texture-bit+               #x00040000) 
+(defconstant +scissor-bit+               #x00080000) 
+(defconstant +all-attrib-bits+           #x000fffff) 
+(defconstant +client-pixel-store-bit+    #x00000001) 
+(defconstant +client-vertex-array-bit+   #x00000002) 
+(defconstant +client-all-attrib-bits+    #xffffffff) 
+
+;; ARB Multitexturing extension
+
+(defconstant +arb-multitexture+                   1) 
+(defconstant +texture0-arb+                  #x84c0) 
+(defconstant +texture1-arb+                  #x84c1) 
+(defconstant +texture2-arb+                  #x84c2) 
+(defconstant +texture3-arb+                  #x84c3) 
+(defconstant +texture4-arb+                  #x84c4) 
+(defconstant +texture5-arb+                  #x84c5) 
+(defconstant +texture6-arb+                  #x84c6) 
+(defconstant +texture7-arb+                  #x84c7) 
+(defconstant +texture8-arb+                  #x84c8) 
+(defconstant +texture9-arb+                  #x84c9) 
+(defconstant +texture10-arb+                 #x84ca) 
+(defconstant +texture11-arb+                 #x84cb) 
+(defconstant +texture12-arb+                 #x84cc) 
+(defconstant +texture13-arb+                 #x84cd) 
+(defconstant +texture14-arb+                 #x84ce) 
+(defconstant +texture15-arb+                 #x84cf) 
+(defconstant +texture16-arb+                 #x84d0) 
+(defconstant +texture17-arb+                 #x84d1) 
+(defconstant +texture18-arb+                 #x84d2) 
+(defconstant +texture19-arb+                 #x84d3) 
+(defconstant +texture20-arb+                 #x84d4) 
+(defconstant +texture21-arb+                 #x84d5) 
+(defconstant +texture22-arb+                 #x84d6) 
+(defconstant +texture23-arb+                 #x84d7) 
+(defconstant +texture24-arb+                 #x84d8) 
+(defconstant +texture25-arb+                 #x84d9) 
+(defconstant +texture26-arb+                 #x84da) 
+(defconstant +texture27-arb+                 #x84db) 
+(defconstant +texture28-arb+                 #x84dc) 
+(defconstant +texture29-arb+                 #x84dd) 
+(defconstant +texture30-arb+                 #x84de) 
+(defconstant +texture31-arb+                 #x84df) 
+(defconstant +active-texture-arb+            #x84e0) 
+(defconstant +client-active-texture-arb+     #x84e1) 
+(defconstant +max-texture-units-arb+         #x84e2) 
+
+;;; Misc extensions
+
+(defconstant +ext-abgr+                           1) 
+(defconstant +abgr-ext+                      #x8000) 
+(defconstant +ext-blend-color+                    1) 
+(defconstant +constant-color-ext+            #x8001) 
+(defconstant +one-minus-constant-color-ext+  #x8002) 
+(defconstant +constant-alpha-ext+            #x8003) 
+(defconstant +one-minus-constant-alpha-ext+  #x8004) 
+(defconstant +blend-color-ext+               #x8005) 
+(defconstant +ext-polygon-offset+                 1) 
+(defconstant +polygon-offset-ext+            #x8037) 
+(defconstant +polygon-offset-factor-ext+     #x8038) 
+(defconstant +polygon-offset-bias-ext+       #x8039) 
+(defconstant +ext-texture3d+                      1) 
+(defconstant +pack-skip-images-ext+          #x806b) 
+(defconstant +pack-image-height-ext+         #x806c) 
+(defconstant +unpack-skip-images-ext+        #x806d) 
+(defconstant +unpack-image-height-ext+       #x806e) 
+(defconstant +texture-3d-ext+                #x806f) 
+(defconstant +proxy-texture-3d-ext+          #x8070) 
+(defconstant +texture-depth-ext+             #x8071) 
+(defconstant +texture-wrap-r-ext+            #x8072) 
+(defconstant +max-3d-texture-size-ext+       #x8073) 
+(defconstant +texture-3d-binding-ext+        #x806a) 
+(defconstant +ext-texture-object+                 1) 
+(defconstant +texture-priority-ext+          #x8066) 
+(defconstant +texture-resident-ext+          #x8067) 
+(defconstant +texture-1d-binding-ext+        #x8068) 
+(defconstant +texture-2d-binding-ext+        #x8069) 
+(defconstant +ext-rescale-normal+                 1) 
+(defconstant +rescale-normal-ext+            #x803a) 
+(defconstant +ext-vertex-array+                   1) 
+(defconstant +vertex-array-ext+              #x8074) 
+(defconstant +normal-array-ext+              #x8075) 
+(defconstant +color-array-ext+               #x8076) 
+(defconstant +index-array-ext+               #x8077) 
+(defconstant +texture-coord-array-ext+       #x8078) 
+(defconstant +edge-flag-array-ext+           #x8079) 
+(defconstant +vertex-array-size-ext+         #x807a) 
+(defconstant +vertex-array-type-ext+         #x807b) 
+(defconstant +vertex-array-stride-ext+       #x807c) 
+(defconstant +vertex-array-count-ext+        #x807d) 
+(defconstant +normal-array-type-ext+         #x807e) 
+(defconstant +normal-array-stride-ext+       #x807f) 
+(defconstant +normal-array-count-ext+        #x8080) 
+(defconstant +color-array-size-ext+          #x8081) 
+(defconstant +color-array-type-ext+          #x8082) 
+(defconstant +color-array-stride-ext+        #x8083) 
+(defconstant +color-array-count-ext+         #x8084) 
+(defconstant +index-array-type-ext+          #x8085) 
+(defconstant +index-array-stride-ext+        #x8086) 
+(defconstant +index-array-count-ext+         #x8087) 
+(defconstant +texture-coord-array-size-ext+  #x8088) 
+(defconstant +texture-coord-array-type-ext+  #x8089) 
+(defconstant +texture-coord-array-stride-ext+ #x808a) 
+(defconstant +texture-coord-array-count-ext+ #x808b) 
+(defconstant +edge-flag-array-stride-ext+    #x808c) 
+(defconstant +edge-flag-array-count-ext+     #x808d) 
+(defconstant +vertex-array-pointer-ext+      #x808e) 
+(defconstant +normal-array-pointer-ext+      #x808f) 
+(defconstant +color-array-pointer-ext+       #x8090) 
+(defconstant +index-array-pointer-ext+       #x8091) 
+(defconstant +texture-coord-array-pointer-ext+ #x8092) 
+(defconstant +edge-flag-array-pointer-ext+   #x8093) 
+(defconstant +sgis-texture-edge-clamp+            1) 
+(defconstant +clamp-to-edge-sgis+            #x812f) 
+(defconstant +ext-blend-minmax+                   1) 
+(defconstant +func-add-ext+                  #x8006) 
+(defconstant +min-ext+                       #x8007) 
+(defconstant +max-ext+                       #x8008) 
+(defconstant +blend-equation-ext+            #x8009) 
+(defconstant +ext-blend-subtract+                 1) 
+(defconstant +func-subtract-ext+             #x800a) 
+(defconstant +func-reverse-subtract-ext+     #x800b) 
+(defconstant +ext-blend-logic-op+                 1) 
+(defconstant +ext-point-parameters+               1) 
+(defconstant +point-size-min-ext+            #x8126) 
+(defconstant +point-size-max-ext+            #x8127) 
+(defconstant +point-fade-threshold-size-ext+ #x8128) 
+(defconstant +distance-attenuation-ext+      #x8129) 
+(defconstant +ext-paletted-texture+               1) 
+(defconstant +table-too-large-ext+           #x8031) 
+(defconstant +color-table-format-ext+        #x80d8) 
+(defconstant +color-table-width-ext+         #x80d9) 
+(defconstant +color-table-red-size-ext+      #x80da) 
+(defconstant +color-table-green-size-ext+    #x80db) 
+(defconstant +color-table-blue-size-ext+     #x80dc) 
+(defconstant +color-table-alpha-size-ext+    #x80dd) 
+(defconstant +color-table-luminance-size-ext+ #x80de) 
+(defconstant +color-table-intensity-size-ext+ #x80df) 
+(defconstant +texture-index-size-ext+        #x80ed) 
+(defconstant +color-index1-ext+              #x80e2) 
+(defconstant +color-index2-ext+              #x80e3) 
+(defconstant +color-index4-ext+              #x80e4) 
+(defconstant +color-index8-ext+              #x80e5) 
+(defconstant +color-index12-ext+             #x80e6) 
+(defconstant +color-index16-ext+             #x80e7) 
+(defconstant +ext-clip-volume-hint+               1) 
+(defconstant +clip-volume-clipping-hint-ext+ #x80f0) 
+(defconstant +ext-compiled-vertex-array+          1) 
+(defconstant +array-element-lock-first-ext+  #x81a8) 
+(defconstant +array-element-lock-count-ext+  #x81a9) 
+(defconstant +hp-occlusion-test+                  1) 
+(defconstant +occlusion-test-hp+             #x8165) 
+(defconstant +occlusion-test-result-hp+      #x8166) 
+(defconstant +ext-shared-texture-palette+         1) 
+(defconstant +shared-texture-palette-ext+    #x81fb) 
+(defconstant +ext-stencil-wrap+                   1) 
+(defconstant +incr-wrap-ext+                 #x8507) 
+(defconstant +decr-wrap-ext+                 #x8508) 
+(defconstant +nv-texgen-reflection+               1) 
+(defconstant +normal-map-nv+                 #x8511) 
+(defconstant +reflection-map-nv+             #x8512) 
+(defconstant +ext-texture-env-add+                1) 
+(defconstant +mesa-window-pos+                    1) 
+(defconstant +mesa-resize-buffers+                1)
+)
+
+
+
+;;; Utility stuff
+
+(deftype bool () 'card8)
+(deftype float32 () 'single-float)
+(deftype float64 () 'double-float)
+
+(declaim (inline aset-float32 aset-float64))
+
+#+sbcl
+(defun aset-float32 (value array index)
+  (declare (type single-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (let ((bits (sb-kernel:single-float-bits value)))
+    (declare (type (unsigned-byte 32) bits))
+    (aset-card32 bits array index))
+  value)
+
+
+#+cmu
+(defun aset-float32 (value array index)
+  (declare (type single-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (let ((bits (kernel:single-float-bits  value)))
+    (declare (type (unsigned-byte 32) bits))
+    (aset-card32 bits array index))
+  value)
+
+
+#+openmcl
+(defun aset-float32 (value array index)
+  (declare (type single-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (let ((bits (ccl::single-float-bits value)))
+    (declare (type (unsigned-byte 32) bits))
+    (aset-card32 bits array index))
+  value)
+
+
+#+lispworks
+(progn
+  (defun %single-float-bits (x)
+    (declare (type single-float x))
+    (fli:with-dynamic-foreign-objects ((bits :int32))
+      (fli:with-coerced-pointer (pointer :type :lisp-single-float) bits
+        (setf (fli:dereference pointer) x))
+      (fli:dereference bits)))
+
+  (declaim (notinline aset-float32))
+  (defun aset-float32 (value array index)
+    (declare (type (or short-float single-float) value)
+             (type buffer-bytes array)
+             (type array-index index))
+    #.(declare-buffun)
+    (let ((bits (%single-float-bits (coerce value 'single-float))))
+      (declare (type (unsigned-byte 32) bits))
+      (aset-card32 bits array index))
+    value))
+
+
+#+sbcl
+(defun aset-float64 (value array index)
+  (declare (type double-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (let ((low (sb-kernel:double-float-low-bits value))
+        (high (sb-kernel:double-float-high-bits value)))
+    (declare (type (unsigned-byte 32) low high))
+    (aset-card32 low array index)
+    (aset-card32 high array (the array-index (+ index 4))))
+  value)
+
+
+#+cmu
+(defun aset-float64 (value array index)
+  (declare (type double-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (let ((low (kernel:double-float-low-bits value))
+        (high (kernel:double-float-high-bits value)))
+    (declare (type (unsigned-byte 32) low high))
+    (aset-card32 low array index)
+    (aset-card32 high array (+ index 4)))
+  value)
+
+
+#+openmcl
+(defun aset-float64 (value array index)
+  (declare (type double-float value)
+           (type buffer-bytes array)
+           (type array-index index))
+  #.(declare-buffun)
+  (multiple-value-bind (low high)
+      (ccl::double-float-bits value)
+    (declare (type (unsigned-byte 32) low high))
+    (aset-card32 low array index)
+    (aset-card32 high array (the array-index (+ index 4))))
+  value)
+
+
+#+lispworks
+(progn
+  (fli:define-c-struct %uint64
+    (high :uint32)
+    (low :uint32))
+
+  (defun %double-float-bits (x)
+    (declare (type double-float x))
+    (fli:with-dynamic-foreign-objects ((bits %uint64))
+      (fli:with-coerced-pointer (pointer :type :lisp-double-float) bits
+        (setf (fli:dereference pointer) x))
+
+      (values (fli:foreign-slot-value bits 'low :type :uint32 :object-type '%uint64)
+              (fli:foreign-slot-value bits 'high :type :uint32 :object-type '%uint64))))
+
+  (declaim (notinline aset-float64))
+  (defun aset-float64 (value array index)
+    (declare (type double-float value)
+             (type buffer-bytes array)
+             (type array-index index))
+    #.(declare-buffun)
+    (multiple-value-bind (low high)
+        (%double-float-bits value)
+      (declare (type (unsigned-byte 32) low high))
+
+      (aset-card32 low array index)
+      (aset-card32 high array (the array-index (+ index 4))))
+    value))
+
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defun byte-width (type)
+  (ecase type
+    ((int8 card8 bool)          1)
+    ((int16 card16)             2)
+    ((int32 card32 float32)     4)
+    ((float64)                  8)))
+
+
+(defun setter (type)
+  (ecase type
+    (int8       'aset-int8)
+    (int16      'aset-int16)
+    (int32      'aset-int32)
+    (bool       'aset-card8)
+    (card8      'aset-card8)
+    (card16     'aset-card16)
+    (card32     'aset-card32)
+    (float32    'aset-float32)
+    (float64    'aset-float64)))
+
+
+(defun sequence-setter (type)
+  (ecase type
+    (int8       'sset-int8)
+    (int16      'sset-int16)
+    (int32      'sset-int32)
+    (bool       'sset-card8)
+    (card8      'sset-card8)
+    (card16     'sset-card16)
+    (card32     'sset-card32)
+    (float32    'sset-float32)
+    (float64    'sset-float64)))
+
+
+(defmacro define-sequence-setter (type)
+  `(defun ,(intern (format nil "~A-~A" 'sset type)) (seq buffer start length)
+     (declare (type sequence seq)
+              (type buffer-bytes buffer)
+              (type array-index start)
+              (type fixnum length))
+     #.(declare-buffun)
+     (assert (= length (length seq))
+             (length seq)
+             "SEQUENCE length should be ~D, not ~D." length (length seq))
+     (typecase seq
+       (list
+        (let ((offset 0))
+          (declare (type fixnum offset))
+          (dolist (n seq)
+            (declare (type ,type n))
+            (,(setter type) n buffer (the array-index (+ start offset)))
+            (incf offset ,(byte-width type)))))
+       ((simple-array ,type)
+        (dotimes (i ,(byte-width type))
+          (,(setter type)
+            (aref seq i)
+            buffer
+            (the array-index (+ start (* i ,(byte-width type)))))))
+       (vector
+        (dotimes (i ,(byte-width type))
+          (,(setter type)
+            (svref seq i)
+            buffer
+            (the array-index (+ start (* i ,(byte-width type))))))))))
+
+
+(define-sequence-setter int8)
+(define-sequence-setter int16)
+(define-sequence-setter int32)
+(define-sequence-setter bool)
+(define-sequence-setter card8)
+(define-sequence-setter card16)
+(define-sequence-setter card32)
+(define-sequence-setter float32)
+(define-sequence-setter float64)
+
+
+
+(defun make-argspecs (list)
+  (destructuring-bind (name type)
+      list
+    (etypecase type
+      (symbol `(,name ,type 1 nil))
+      (list
+       `(,name
+         ,(second type)
+         ,(third type)
+         ,(if (consp (third type))
+              (make-symbol (format nil "~A-~A" name 'length))
+              nil))))))
+
+
+(defun byte-width-calculation (argspecs)
+  (let ((constant 0)
+        (calculated ()))
+    (loop
+       for (name type length length-var) in argspecs
+       do (let ((byte-width (byte-width type)))
+            (typecase length
+              (number (incf constant (* byte-width length)))
+              (symbol (push `(* ,byte-width ,length) calculated))
+              (cons  (push `(* ,byte-width ,length-var) calculated)))))
+    (if (null calculated)
+        constant
+        (list* '+ constant calculated))))
+
+
+(defun composite-args (argspecs)
+  (loop
+     for (name type length length-var) in argspecs
+     when (consp length)
+     collect (list length-var length)))
+
+
+(defun make-setter-forms (argspecs)
+  (loop
+     for (name type length length-var) in argspecs
+     collecting `(progn
+                   ,(if (and (numberp length)
+                             (= 1 length))
+                        `(,(setter type) ,name .rbuf. .index.)
+                        `(,(sequence-setter type) ,name .rbuf. .index.
+                           ,(if length-var length-var length)))
+                   (setf .index. (the array-index
+                                   (+ .index.
+                                      (the fixnum (* ,(byte-width type)
+                                                     ,(if length-var length-var length)))))))))
+
+
+(defmacro define-rendering-command (name opcode &rest args)
+  ;; FIXME: Must heavily type-annotate.
+  (labels ((expand-args (list)
+             (loop
+                for (arg type) in list
+                if (consp arg)
+                append (loop
+                          for name in arg
+                          collecting (list name type))
+                else
+                collect (list arg type))))
+
+    (let* ((args (expand-args args))
+           (argspecs (mapcar 'make-argspecs args))
+           (total-byte-width (byte-width-calculation argspecs))
+           (composite-args (composite-args argspecs)))
+      
+      `(defun ,name ,(mapcar #'first argspecs)
+         (declare ,@(mapcar #'(lambda (list)
+                                (if (symbolp (second list))
+                                    (list* 'type (reverse list))
+                                    `(type sequence ,(first list))))
+                            args))
+         #.(declare-buffun)
+         (assert (context-p *current-context*)
+                 (*current-context*)
+                 "*CURRENT-CONTEXT* is not set (~S)." *current-context*)
+         (let* ((.ctx. *current-context*)
+                (.index0. (context-index .ctx.))
+                (.index. (+ .index0. 4))
+                (.rbuf. (context-rbuf .ctx.))
+                ,@composite-args
+                (.length. (+ 4 (* 4 (ceiling ,total-byte-width 4)))))
+
+           (declare (type context .ctx.)
+                    (type array-index .index. .index0.)
+                    (type buffer-bytes .rbuf.)
+                    ,@(mapcar #'(lambda (list)
+                                  `(type fixnum ,(first list)))
+                              composite-args)
+                    (type fixnum .length.))
+
+           (when (< (- (length .rbuf.) 8)
+                    (+ .index. .length.))
+             (error "Rendering command sequence too long.  Implement automatic buffer flushing."))
+
+           (aset-card16 .length. .rbuf. (the array-index .index0.))
+           (aset-card16 ,opcode .rbuf. (the array-index (+ .index0. 2)))
+           ,@(make-setter-forms argspecs)
+           (setf (context-index .ctx.) (the array-index (+ .index0. .length.))))))))
+
+) ;; eval-when
+
+
+;;; Command implementation.
+
+
+(defun get-string (name)
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "*CURRENT-CONTEXT* is not set (~S)." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +get-string+)
+         ;; *** This is CONTEXT-TAG
+         (card32 (context-tag ctx))
+         ;; *** This is ENUM.
+         (card32 name))
+      (let* ((length (card32-get 12))
+             (bytes (sequence-get :format card8
+                                  :result-type '(simple-array card8 (*))
+                                  :index 32
+                                  :length length)))
+        (declare (type (simple-array card8 (*)) bytes)
+                 (type fixnum length))
+        ;; FIXME: How does this interact with unicode?
+        (map-into (make-string (1- length)) #'code-char bytes)))))
+
+
+
+
+;;; Rendering commands (in alphabetical order).
+
+
+(define-rendering-command accum 137
+  ;; *** ENUM
+  (op           card32)
+  (value        float32))
+
+
+(define-rendering-command active-texture-arb 197
+  ;; *** ENUM
+  (texture      card32))
+
+
+(define-rendering-command alpha-func 159
+  ;; *** ENUM
+  (func         card32)
+  (ref          float32))
+
+
+(define-rendering-command begin 4
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command bind-texture 4117
+  ;; *** ENUM
+  (target       card32)
+  (texture      card32))
+
+
+(define-rendering-command blend-color 4096
+  (red          float32)
+  (green        float32)
+  (blue         float32)
+  (alpha        float32))
+
+
+(define-rendering-command blend-equotion 4097
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command blend-func 160
+  ;; *** ENUM
+  (sfactor      card32)
+  ;; *** ENUM
+  (dfactor      card32))
+
+
+(define-rendering-command call-list 1
+  (list         card32))
+
+
+(define-rendering-command clear 127
+  ;; *** BITFIELD
+  (mask         card32))
+
+
+(define-rendering-command clear-accum 128
+  (red          float32)
+  (green        float32)
+  (blue         float32)
+  (alpha        float32))
+
+
+(define-rendering-command clear-color 130 
+  (red          float32)
+  (green        float32)
+  (blue         float32)
+  (alpha        float32))
+
+
+(define-rendering-command clear-depth 132
+  (depth        float64))
+
+
+(define-rendering-command clear-index 129
+  (c            float32))
+
+
+(define-rendering-command clear-stencil 131
+  (s            int32))
+
+
+(define-rendering-command clip-plane 77
+  (equotion-0   float64)
+  (equotion-1   float64)
+  (equotion-2   float64)
+  (equotion-3   float64)
+  ;; *** ENUM
+  (plane        card32))
+
+
+(define-rendering-command color-3b 6
+  ((r g b)      int8))
+
+(define-rendering-command color-3d 7
+  ((r g b)      float64))
+
+(define-rendering-command color-3f 8
+  ((r g b)      float32))
+
+(define-rendering-command color-3i 9
+  ((r g b)      int32))
+
+(define-rendering-command color-3s 10
+  ((r g b)      int16))
+
+(define-rendering-command color-3ub 11
+  ((r g b)      card8))
+
+(define-rendering-command color-3ui 12
+  ((r g b)      card32))
+
+(define-rendering-command color-3us 13
+  ((r g b)      card16))
+
+
+(define-rendering-command color-4b 14
+  ((r g b a)    int8))
+
+(define-rendering-command color-4d 15
+  ((r g b a)    float64))
+
+(define-rendering-command color-4f 16
+  ((r g b a)    float32))
+
+(define-rendering-command color-4i 17
+  ((r g b a)    int32))
+
+(define-rendering-command color-4s 18
+  ((r g b a)    int16))
+
+(define-rendering-command color-4ub 19
+  ((r g b a)    card8))
+
+(define-rendering-command color-4ui 20
+  ((r g b a)    card32))
+
+(define-rendering-command color-4us 21
+  ((r g b a)    card16))
+
+
+(define-rendering-command color-mask 134
+  (red          bool)
+  (green        bool)
+  (blue         bool)
+  (alpha        bool))
+
+
+(define-rendering-command color-material 78
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command color-table-parameter-fv 2054
+  ;; *** ENUM
+  (target       card32)
+  ;; TODO:
+  ;; +GL-COLOR-TABLE-SCALE+ (#x80D6) => (length params) = 4
+  ;; +GL-COLOR-TABLE-BIAS+ (#x80d7) => (length params) = 4
+  ;; else (length params) = 0 (command is erronous)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 4)))
+
+
+(define-rendering-command color-table-parameter-iv 2055
+  ;; *** ENUM
+  (target       card32)
+  ;; TODO:
+  ;; +GL-COLOR-TABLE-SCALE+ (#x80D6) => (length params) = 4
+  ;; +GL-COLOR-TABLE-BIAS+ (#x80d7) => (length params) = 4
+  ;; else (length params) = 0 (command is erronous)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 4)))
+
+
+(define-rendering-command convolution-parameter-f 4103
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       float32))
+
+
+(define-rendering-command convolution-parameter-fv 4104
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+convolution-border-mode+
+                                  #.+convolution-format+
+                                  #.+convolution-width+
+                                  #.+convolution-height+
+                                  #.+max-convolution-width+
+                                  #.+max-convolution-height+)
+                                 1)
+                                ((#.+convolution-filter-scale+
+                                  #.+convolution-filter-bias+)
+                                 4)))))
+
+
+(define-rendering-command convolution-parameter-i 4105
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       int32))
+
+
+(define-rendering-command convolution-parameter-iv 4106
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+convolution-border-mode+
+                                #.+convolution-format+
+                                #.+convolution-width+
+                                #.+convolution-height+
+                                #.+max-convolution-width+
+                                #.+max-convolution-height+)
+                               1)
+                              ((#.+convolution-filter-scale+
+                                #.+convolution-filter-bias+)
+                               4)))))
+
+
+(define-rendering-command copy-color-sub-table 196
+  ;; *** ENUM
+  (target       card32)
+  (start        int32)
+  (x            int32)
+  (y            int32)
+  (width        int32))
+
+
+(define-rendering-command copy-color-table 2056
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (internalformat card32)
+  (x            int32)
+  (y            int32)
+  (width        int32))
+
+
+(define-rendering-command copy-convolution-filter-id 4107
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (internalformat card32)
+  (x            int32)
+  (y            int32)
+  (width        int32))
+
+
+(define-rendering-command copy-convolution-filter-2d 4108
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (internalformat card32)
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (height       int32))
+
+
+(define-rendering-command copy-pixels 172
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (height       int32)
+  ;; *** ENUM
+  (type         card32))
+
+
+(define-rendering-command copy-tex-image-1d 4119
+  ;; *** ENUM
+  (target       card32)
+  (level        int32)
+  ;; *** ENUM
+  (internalformat card32)
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (border       int32))
+
+
+(define-rendering-command copy-tex-image-2d 4120
+  ;; *** ENUM
+  (target       card32)
+  (level        int32)
+  ;; *** ENUM
+  (internalformat card32)
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (height       int32)
+  (border       int32))
+
+
+(define-rendering-command copy-tex-sub-image-1d 4121
+  ;; *** ENUM
+  (target       card32)
+  (level        int32)
+  (xoffset      int32)
+  (x            int32)
+  (y            int32)
+  (width        int32))
+
+
+(define-rendering-command copy-tex-sub-image-2d 4122
+  ;; *** ENUM
+  (target       card32)
+  (level        int32)
+  (xoffset      int32)
+  (yoffset      int32)
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (height       int32))
+
+
+(define-rendering-command copy-tex-sub-image-3d 4123
+  ;; *** ENUM
+  (target       card32)
+  (level        int32)
+  (xoffset      int32)
+  (yoffset      int32)
+  (zoffset      int32)
+  (x            int32)
+  (y            int32)
+  (width        int32)
+  (height       int32))
+
+
+(define-rendering-command cull-face 79
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command depth-func 164
+  ;; *** ENUM
+  (func         card32))
+
+
+(define-rendering-command depth-mask 135
+  (mask         bool))
+
+
+(define-rendering-command depth-range 174
+  (z-near       float64)
+  (z-far        float64))
+
+
+(define-rendering-command draw-buffer 126
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command edge-flag-v 22
+  (flag-0       bool))
+
+
+(define-rendering-command end 23)
+
+
+(define-rendering-command eval-coord-1d 151
+  (u-0          float64))
+
+(define-rendering-command eval-coord-1f 152
+  (u-0          float32))
+
+
+(define-rendering-command eval-coord-2d 153
+  ((u-0 u-1)    float64))
+
+(define-rendering-command eval-coord-2f 154
+  ((u-0 u-1)    float32))
+
+
+(define-rendering-command eval-mesh-1 155
+  ;; *** ENUM
+  (mode         card32)
+  ((i1 i2)      int32))
+
+
+(define-rendering-command eval-mesh-2 157
+  ;; *** ENUM
+  (mode         card32)
+  ((i1 i2 j1 j2) int32))
+
+
+(define-rendering-command eval-point-1 156
+  (i            int32))
+
+
+(define-rendering-command eval-point-2 158
+  (i            int32)
+  (j            int32))
+
+
+(define-rendering-command fog-f 80
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command fog-fv 81
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+fog-index+
+                                  #.+fog-density+
+                                  #.+fog-start+
+                                  #.+fog-end+
+                                  #.+fog-mode+)
+                                 1)
+                                ((#.+fog-color+)
+                                 4)))))
+
+
+
+(define-rendering-command fog-i 82
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command fog-iv 83
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+fog-index+
+                                #.+fog-density+
+                                #.+fog-start+
+                                #.+fog-end+
+                                #.+fog-mode+)
+                               1)
+                              ((#.+fog-color+)
+                               4)))))
+
+
+(define-rendering-command front-face 84
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command frustum 175
+  (left         float64)
+  (right        float64)
+  (bottom       float64)
+  (top          float64)
+  (z-near       float64)
+  (z-far        float64))
+
+
+(define-rendering-command hint 85
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command histogram 4110
+  ;; *** ENUM
+  (target       card32)
+  (width        int32)
+  ;; *** ENUM
+  (internalformat card32)
+  (sink         bool))
+
+
+(define-rendering-command index-mask 136
+  (mask         card32))
+
+
+(define-rendering-command index-d 24
+  (c-0          float64))
+
+(define-rendering-command index-f 25
+  (c-0          float32))
+
+(define-rendering-command index-i 26
+  (c-0          int32))
+
+(define-rendering-command index-s 27
+  (c-0          int16))
+
+(define-rendering-command index-ub 194
+  (c-0          card8))
+
+
+(define-rendering-command init-names 121)
+
+
+(define-rendering-command light-model-f 90
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command light-model-fv 91
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+light-model-color-control+
+                                  #.+light-model-local-viewer+
+                                  #.+light-model-two-side+)
+                                 1)
+                                ((#.+light-model-ambient+)
+                                 4)))))
+
+(define-rendering-command light-model-i 92
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command light-model-iv 93
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+light-model-color-control+
+                                #.+light-model-local-viewer+
+                                #.+light-model-two-side+)
+                               1)
+                              ((#.+light-model-ambient+)
+                               4)))))
+
+
+(define-rendering-command light-f 86
+  ;; *** ENUM
+  (light        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command light-fv 87
+  ;; *** ENUM
+  (light        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+ambient+
+                                  #.+diffuse+
+                                  #.+specular+
+                                  #.+position+)
+                                 4)
+                                ((#.+spot-direction+)
+                                 3)
+                                ((#.+spot-exponent+
+                                  #.+spot-cutoff+
+                                  #.+constant-attenuation+
+                                  #.+linear-attenuation+
+                                  #.+quadratic-attenuation+)
+                                 1)))))
+
+
+(define-rendering-command light-i 88
+  ;; *** ENUM
+  (light        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command light-iv 89
+  ;; *** ENUM
+  (light        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+ambient+
+                                #.+diffuse+
+                                #.+specular+
+                                #.+position+)
+                               4)
+                              ((#.+spot-direction+)
+                               3)
+                              ((#.+spot-exponent+
+                                #.+spot-cutoff+
+                                #.+constant-attenuation+
+                                #.+linear-attenuation+
+                                #.+quadratic-attenuation+)
+                               1)))))
+
+
+(define-rendering-command line-stipple 94
+  (factor       int32)
+  (pattern      card16))
+
+
+(define-rendering-command line-width 95
+  (width        float32))
+
+
+(define-rendering-command list-base 3
+  (base         card32))
+
+
+(define-rendering-command load-identity 176)
+
+
+(define-rendering-command load-matrix-d 178
+  (m            (list float64 16)))
+
+
+(define-rendering-command load-matrix-f 177
+  (m            (list float32 16)))
+
+
+(define-rendering-command load-name 122
+  (name         card32))
+
+
+(define-rendering-command logic-op 161
+  ;; *** ENUM
+  (name         card32))
+
+
+(define-rendering-command map-grid-1d 147
+  (u1           float64)
+  (u2           float64)
+  (un           int32))
+
+(define-rendering-command map-grid-1f 148
+  (un           int32)
+  (u1           float32)
+  (u2           float32))
+
+
+(define-rendering-command map-grid-2d 149
+  (u1           float64)
+  (u2           float64)
+  (v1           float64)
+  (v2           float64)
+  (un           int32)
+  (vn           int32))
+
+
+(define-rendering-command map-grid-2f 150
+  (un           int32)
+  (u1           float32)
+  (u2           float32)
+  (vn           int32)
+  (v1           float32)
+  (v2           float32))
+
+
+(define-rendering-command material-f 96
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command material-fv 97
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+ambient+
+                                  #.+diffuse+
+                                  #.+specular+
+                                  #.+emission+
+                                  #.+ambient-and-diffuse+)
+                                 4)
+                                ((#.+shininess+)
+                                 1)
+                                ((#.+color-index+)
+                                 3)))))
+
+
+(define-rendering-command material-i 98
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command material-iv 99
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+ambient+
+                                #.+diffuse+
+                                #.+specular+
+                                #.+emission+
+                                #.+ambient-and-diffuse+)
+                               4)
+                              ((#.+shininess+)
+                               1)
+                              ((#.+color-index+)
+                               3)))))
+
+
+(define-rendering-command matrix-mode 179
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command minmax 4111
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (internalformat card32)
+  (sink         bool))
+
+
+(define-rendering-command mult-matrix-d 181
+  (m            (list float64 16)))
+
+
+(define-rendering-command mult-matrix-f 180
+  (m            (list float32 16)))
+
+
+;;; *** Note that TARGET is placed last for FLOAT64 versions.
+(define-rendering-command multi-tex-coord-1d-arb 198
+  (v-0          float64)
+  ;; *** ENUM
+  (target       card32))
+
+(define-rendering-command multi-tex-coord-1f-arb 199
+  ;; *** ENUM
+  (target       card32)
+  (v-0          float32))
+
+(define-rendering-command multi-tex-coord-1i-arb 200
+  ;; *** ENUM
+  (target       card32)
+  (v-0          int32))
+
+(define-rendering-command multi-tex-coord-1s-arb 201
+  ;; *** ENUM
+  (target       card32)
+  (v-0          int16))
+
+
+(define-rendering-command multi-tex-coord-2d-arb 202
+  ((v-0 v-1)    float64)
+  ;; *** ENUM
+  (target       card32))
+
+(define-rendering-command multi-tex-coord-2f-arb 203
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1)    float32))
+
+(define-rendering-command multi-tex-coord-2i-arb 204
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1)    int32))
+
+(define-rendering-command multi-tex-coord-2s-arb 205
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1)    int16))
+
+
+(define-rendering-command multi-tex-coord-3d-arb 206
+  ((v-0 v-1 v-2) float64)
+  ;; *** ENUM
+  (target       card32))
+
+(define-rendering-command multi-tex-coord-3f-arb 207
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2) float32))
+
+(define-rendering-command multi-tex-coord-3i-arb 208
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2) int32))
+
+(define-rendering-command multi-tex-coord-3s-arb 209
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2) int16))
+
+
+(define-rendering-command multi-tex-coord-4d-arb 210
+  ((v-0 v-1 v-2 v-3) float64)
+  ;; *** ENUM
+  (target       card32))
+
+(define-rendering-command multi-tex-coord-4f-arb 211
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2 v-3) float32))
+
+(define-rendering-command multi-tex-coord-4i-arb 212
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2 v-3) int32))
+
+(define-rendering-command multi-tex-coord-4s-arb 213
+  ;; *** ENUM
+  (target       card32)
+  ((v-0 v-1 v-2 v-3) int16))
+
+
+(define-rendering-command normal-3b 28
+  ((v-0 v-1 v-2) int8))
+
+(define-rendering-command normal-3d 29
+  ((v-0 v-1 v-2) float64))
+
+(define-rendering-command normal-3f 30
+  ((v-0 v-1 v-2) float32))
+
+(define-rendering-command normal-3i 31
+  ((v-0 v-1 v-2) int32))
+
+(define-rendering-command normal-3s 32
+  ((v-0 v-1 v-2) int16))
+
+
+(define-rendering-command ortho 182
+  (left         float64)
+  (right        float64)
+  (bottom       float64)
+  (top          float64)
+  (z-near       float64)
+  (z-far        float64))
+
+
+(define-rendering-command pass-through 123
+  (token        float32))
+
+
+(define-rendering-command pixel-transfer-f 166
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command pixel-transfer-i 167
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command pixel-zoom 165
+  (xfactor      float32)
+  (yfactor      float32))
+
+
+(define-rendering-command point-size 100
+  (size         float32))
+
+
+(define-rendering-command polygon-mode 101
+  ;; *** ENUM
+  (face         card32)
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command polygon-offset 192
+  (factor       float32)
+  (units        float32))
+
+
+(define-rendering-command pop-attrib 141)
+
+
+(define-rendering-command pop-matrix 183)
+
+
+(define-rendering-command pop-name 124)
+
+
+(define-rendering-command prioritize-textures 4118
+  (n            int32)
+  (textures     (list card32 n))
+  (priorities   (list float32 n)))
+
+
+(define-rendering-command push-attrib 142
+  ;; *** BITFIELD
+  (mask         card32))
+
+
+(define-rendering-command push-matrix 184)
+
+
+(define-rendering-command push-name 125
+  (name         card32))
+
+
+(define-rendering-command raster-pos-2d 33
+  ((v-0 v-1)    float64))
+
+(define-rendering-command raster-pos-2f 34
+  ((v-0 v-1)    float32))
+
+(define-rendering-command raster-pos-2i 35
+  ((v-0 v-1)    int32))
+
+(define-rendering-command raster-pos-2s 36
+  ((v-0 v-1)    int16))
+
+
+(define-rendering-command raster-pos-3d 37
+  ((v-0 v-1 v-2) float64))
+
+(define-rendering-command raster-pos-3f 38
+  ((v-0 v-1 v-2) float32))
+
+(define-rendering-command raster-pos-3i 39
+  ((v-0 v-1 v-2) int32))
+
+(define-rendering-command raster-pos-3s 40
+  ((v-0 v-1 v-2) int16))
+
+
+(define-rendering-command raster-pos-4d 41
+  ((v-0 v-1 v-2 v-3) float64))
+
+(define-rendering-command raster-pos-4f 42
+  ((v-0 v-1 v-2 v-3) float32))
+
+(define-rendering-command raster-pos-4i 43
+  ((v-0 v-1 v-2 v-3) int32))
+
+(define-rendering-command raster-pos-4s 44
+  ((v-0 v-1 v-2 v-3) int16))
+
+
+(define-rendering-command read-buffer 171
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command rect-d 45
+  ((v1-0 v1-1 v2-0 v2-1) float64))
+
+(define-rendering-command rect-f 46
+  ((v1-0 v1-1 v2-0 v2-1) float32))
+
+(define-rendering-command rect-i 47
+  ((v1-0 v1-1 v2-0 v2-1) int32))
+
+(define-rendering-command rect-s 48
+  ((v1-0 v1-1 v2-0 v2-1) int16))
+
+
+(define-rendering-command reset-histogram 4112
+  ;; *** ENUM
+  (target       card32))
+
+
+(define-rendering-command reset-minmax 4113
+  ;; *** ENUM
+  (target       card32))
+
+
+(define-rendering-command rotate-d 185
+  ((angle x y z) float64))
+
+
+(define-rendering-command rotate-f 186
+  ((angle x y z) float32))
+
+
+(define-rendering-command scale-d 187
+  ((x y z)      float64))
+
+
+(define-rendering-command scale-f 188
+  ((x y z)      float32))
+
+
+(define-rendering-command scissor 103
+  ((x y width height) int32))
+
+
+(define-rendering-command shade-model 104
+  ;; *** ENUM
+  (mode         card32))
+
+
+(define-rendering-command stencil-func 162
+  ;; *** ENUM
+  (func         card32)
+  (ref          int32)
+  (mask         card32))
+
+
+(define-rendering-command stencil-mask 133
+  (mask         card32))
+
+
+(define-rendering-command stencil-op 163
+  ;; *** ENUM
+  (fail         card32)
+  ;; *** ENUM
+  (zfail        card32)
+  ;; *** ENUM
+  (zpass        card32))
+
+
+(define-rendering-command tex-env-f 111
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command tex-env-fv 112
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        (list float32 (ecase pname
+                                (#.+texture-env-mode+ 1)
+                                (#.+texture-env-color+ 4)))))
+
+
+(define-rendering-command tex-env-i 113
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command tex-env-iv 114
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        (list int32 (ecase pname
+                              (#.+texture-env-mode+ 1)
+                              (#.+texture-env-color+ 4)))))
+
+
+;;; *** 
+;;; last there.
+(define-rendering-command tex-gen-d 115
+  (param        float64)
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32))
+
+
+(define-rendering-command tex-gen-dv 116
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32)
+  ;; +texture-gen-mode+ n=1
+  ;; +object-plane+     n=4
+  ;; +eye-plane+        n=1
+  (params       (list float64 (ecase pname
+                                ((#.+texture-gen-mode+ #.+eye-plane+) 1)
+                                (#.+object-plane+ 4)))))
+
+
+(define-rendering-command tex-gen-f 117
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command tex-gen-fv 118
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+texture-gen-mode+ #.+eye-plane+) 1)
+                                (#.+object-plane+ 4)))))
+
+
+(define-rendering-command tex-gen-i 119
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command tex-gen-iv 120
+  ;; *** ENUM
+  (coord        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+texture-gen-mode+ #.+eye-plane+) 1)
+                              (#.+object-plane+ 4)))))
+
+
+(define-rendering-command tex-parameter-f 105
+  ;; *** ENUM
+  (target        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        float32))
+
+
+(define-rendering-command tex-parameter-fv 106
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list float32 (ecase pname
+                                ((#.+texture-border-color+)
+                                 4)
+                                ((#.+texture-mag-filter+
+                                  #.+texture-min-filter+
+                                  #.+texture-wrap-s+
+                                  #.+texture-wrap-t+)
+                                 1)))))
+
+
+(define-rendering-command tex-parameter-i 107
+  ;; *** ENUM
+  (target        card32)
+  ;; *** ENUM
+  (pname        card32)
+  (param        int32))
+
+
+(define-rendering-command tex-parameter-iv 108
+  ;; *** ENUM
+  (target       card32)
+  ;; *** ENUM
+  (pname        card32)
+  (params       (list int32 (ecase pname
+                              ((#.+texture-border-color+)
+                               4)
+                              ((#.+texture-mag-filter+
+                                #.+texture-min-filter+
+                                #.+texture-wrap-s+
+                                #.+texture-wrap-t+)
+                               1)))))
+
+
+(define-rendering-command translate-d 189
+  ((x y z)      float64))
+
+(define-rendering-command translate-f 190
+  ((x y z)      float32))
+
+
+(define-rendering-command vertex-2d 65
+  ((x y)        float64))
+
+(define-rendering-command vertex-2f 66
+  ((x y)        float32))
+
+(define-rendering-command vertex-2i 67
+  ((x y)        int32))
+
+(define-rendering-command vertex-2s 68
+  ((x y)        int16))
+
+
+(define-rendering-command vertex-3d 69
+  ((x y z)      float64))
+
+(define-rendering-command vertex-3f 70
+  ((x y z)      float32))
+
+(define-rendering-command vertex-3i 71
+  ((x y z)      int32))
+
+(define-rendering-command vertex-3s 72
+  ((x y z)      int16))
+
+
+(define-rendering-command vertex-4d 73
+  ((x y z w)    float64))
+
+(define-rendering-command vertex-4f 74
+  ((x y z w)    float32))
+
+(define-rendering-command vertex-4i 75
+  ((x y z w)    int32))
+
+(define-rendering-command vertex-4s 76
+  ((x y z w)    int16))
+
+
+(define-rendering-command viewport 191
+  ((x y width height) int32))
+
+
+;;; Potentially lerge rendering commands.
+
+
+#-(and)
+(define-large-rendering-command call-lists 2
+  (n            int32)
+  ;; *** ENUM
+  (type         card32)
+  (lists        (list type n)))
+
+
+
+;;; Requests for GL non-rendering commands.
+
+(defun new-list (list mode)
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +new-list+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx))
+      (card32 list)
+      ;; *** ENUM
+      (card32 mode))))
+
+
+(defun gen-lists (range)
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +gen-lists+)
+         ;; *** GLX_CONTEXT_TAG
+         (card32 (context-tag ctx))
+         (integer range))
+      (card32-get 8))))
+
+
+(defun end-list ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +end-list+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx)))))
+
+
+(defun enable (cap)
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +enable+)
+         ;; *** GLX_CONTEXT_TAG
+         (card32 (context-tag ctx))
+         ;; *** ENUM?
+         (card32 cap)))))
+
+
+;;; FIXME: FLUSH and FINISH should send *all* buffered data, including
+;;; buffered rendering commands.
+(defun flush ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +flush+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx)))))
+
+
+(defun finish ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +finish+)
+         ;; *** GLX_CONTEXT_TAG
+         (card32 (context-tag ctx))))))

--- a/extensions/glx.lisp
+++ b/extensions/glx.lisp
@@ -1,0 +1,632 @@
+(defpackage :glx
+  (:use :common-lisp :xlib)
+  (:import-from :xlib
+                "DEFINE-ACCESSOR"
+                "DEF-CLX-CLASS"
+                "DECLARE-EVENT"
+                "ALLOCATE-RESOURCE-ID"
+                "DEALLOCATE-RESOURCE-ID"
+                "PRINT-DISPLAY-NAME"
+                "WITH-BUFFER-REQUEST"
+                "WITH-BUFFER-REQUEST-AND-REPLY"
+                "READ-CARD32"
+                "WRITE-CARD32"
+                "CARD32-GET"
+                "CARD8-GET"
+                "SEQUENCE-GET"
+                "SEQUENCE-PUT"
+                "DATA"
+
+                ;; Types
+                "ARRAY-INDEX"
+                "BUFFER-BYTES"
+
+                "WITH-DISPLAY"
+                "BUFFER-FLUSH"
+                "BUFFER-WRITE"
+                "BUFFER-FORCE-OUTPUT"
+                "ASET-CARD8"
+                "ASET-CARD16"
+                "ASET-CARD32"
+                )
+  (:export ;; Constants
+           "+VENDOR+"
+           "+VERSION+"
+           "+EXTENSIONS+"
+
+           ;; Conditions
+           "BAD-CONTEXT"
+           "BAD-CONTEXT-STATE"
+           "BAD-DRAWABLE"
+           "BAD-PIXMAP"
+           "BAD-CONTEXT-TAG"
+           "BAD-CURRENT-WINDOW"
+           "BAD-RENDER-REQUEST"
+           "BAD-LARGE-REQUEST"
+           "UNSUPPORTED-PRIVATE-REQUEST"
+           "BAD-FB-CONFIG"
+           "BAD-PBUFFER"
+           "BAD-CURRENT-DRAWABLE"
+           "BAD-WINDOW"
+
+           ;; Requests
+           "QUERY-VERSION"
+           "QUERY-SERVER-STRING"
+           "CREATE-CONTEXT"
+           "DESTROY-CONTEXT"
+           "IS-DIRECT"
+           "QUERY-CONTEXT"
+           "GET-DRAWABLE-ATTRIBUTES"
+           "MAKE-CURRENT"
+           ;;"GET-VISUAL-CONFIGS"
+           "CHOOSE-VISUAL"
+           "VISUAL-ATTRIBUTE"
+           "VISUAL-ID"
+           "RENDER"
+           "SWAP-BUFFERS"
+           "WAIT-GL"
+           "WAIT-X"
+           ))
+
+
+(in-package :glx)
+
+
+(declaim (optimize (debug 3) (safety 3)))
+
+
+(define-extension "GLX"
+    :events (:glx-pbuffer-clobber)
+    :errors (bad-context
+             bad-context-state
+             bad-drawable
+             bad-pixmap
+             bad-context-tag
+             bad-current-window
+             bad-render-request
+             bad-large-request
+             unsupported-private-request
+             bad-fb-config
+             bad-pbuffer
+             bad-current-drawable
+             bad-window))
+
+
+;;; Opcodes.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defconstant +render+ 1)
+(defconstant +create-context+ 3)
+(defconstant +destroy-context+ 4)
+(defconstant +make-current+ 5)
+(defconstant +is-direct+ 6)
+(defconstant +query-version+ 7)
+(defconstant +wait-gl+ 8)
+(defconstant +wait-x+ 9)
+(defconstant +copy-context+ 10)
+(defconstant +swap-buffers+ 11)
+(defconstant +get-visual-configs+ 14)
+(defconstant +destroy-glx-pixmap+ 15)
+(defconstant +query-server-string+ 19)
+(defconstant +client-info+ 20)
+(defconstant +get-fb-configs+ 21)
+(defconstant +query-context+ 25)
+(defconstant +get-drawable-attributes+ 29)
+)
+
+
+;;; Constants
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defconstant +vendor+ 1)
+(defconstant +version+ 2)
+(defconstant +extensions+ 3)
+)
+
+
+;;; Types
+
+;;; FIXME:
+;;; - Are all the 32-bit values unsigned?  Do we care?
+;;; - These are not used much, yet.
+(progn
+  (deftype attribute-pair ())
+  (deftype bitfield () 'mask32)
+  (deftype bool32 () 'card32)           ; 1 for true and 0 for false 
+  (deftype enum () 'card32)
+  (deftype fbconfigid () 'card32)
+  ;; FIXME: How to define these two?
+  (deftype float32 () 'single-float)
+  (deftype float64 () 'double-float)
+  ;;(deftype glx-context () 'card32)
+  (deftype context-tag () 'card32)
+  ;;(deftype glx-drawable () 'card32)
+  (deftype glx-pixmap () 'card32)
+  (deftype glx-pbuffer () 'card32)
+  (deftype glx-render-command () #|TODO|#)
+  (deftype glx-window () 'card32)
+  #-(and)
+  (deftype visual-property ()
+    "An ordered list of 32-bit property values followed by unordered pairs of
+property types and property values."
+    ;; FIXME: maybe CLX-LIST or even just LIST?
+    'clx-sequence))
+
+
+;;; FIXME: DEFINE-ACCESSOR interns getter and setter in XLIB package
+;;; (using XINTERN).  Therefore the accessors defined below can only
+;;; be accessed using double-colon, which is a bad style.  Or these
+;;; forms must be taken to another file so the accessors exist before
+;;; we get to this file.
+
+#-(and)
+(define-accessor glx-context-tag (32)
+  ((index) `(read-card32 ,index))
+  ((index thing) `(write-card32 ,index ,thing)))
+
+#-(and)
+(define-accessor glx-enum (32)
+  ((index) `(read-card32 ,index))
+  ((index thing) `(write-card32 ,index ,thing)))
+
+
+;;; FIXME: I'm just not sure we need a seperate accessors for what
+;;; essentially are aliases for other types.  Maybe use compiler
+;;; macros?
+;;;
+;;; This trick won't do because CLX wants e.g. CONTEXT-TAG to be a
+;;; known accessor.  The only trick left I think is to change the
+;;; XINTERN function to intern the new symbols in the same package as
+;;; he symbol part of it comes from.  Don't know if it would break
+;;; anything, thought.  (I would be quite surprised if it did -- there
+;;; is only one package in CLX after all: XLIB.)
+;;;
+;;; I also found the origin of the error (about symbol not being a
+;;; known accessor): INDEX-INCREMENT function.  Looks like all we have
+;;; to do is to add an XLIB::BYTE-WIDTH property to the type symbol
+;;; plist.  But accessors are macros, not functions, anyway.
+
+#-(and)
+(progn
+  (declaim (inline context-tag-get context-tag-put enum-get enum-put))
+  (defun context-tag-get (index) (card32-get index))
+  (defun context-tag-put (index thing) (card32-put index thing))
+  (defun enum-get (index) (card32-get index))
+  (defun enum-put (index thing) (card32-put index thing))
+)
+
+
+;;; Structures
+
+
+(def-clx-class (context (:constructor %make-context)
+                        (:print-function print-context)
+                        (:copier nil))
+  (id 0 :type resource-id)
+  (display nil :type (or null display))
+  (tag 0 :type card32)
+  (drawable nil :type (or null drawable))
+  ;; TODO: There can only be one current context (as far as I
+  ;; understand).  If so, we'd need only one buffer (otherwise it's a
+  ;; big waste to have a quarter megabyte buffer for each context; or
+  ;; we could allocate/grow the buffer on demand).
+  ;;
+  ;; 256k buffer for Render command.  Big requests are served with
+  ;; RenderLarge command.  First 8 octets are Render request fields.
+  ;;
+  (rbuf (make-array (+ 8 (* 256 1024)) :element-type '(unsigned-byte 8)) :type buffer-bytes)
+  ;; Index into RBUF where the next rendering command should be inserted.
+  (index 8 :type array-index))
+
+
+(defun print-context (ctx stream depth)
+  (declare (type context ctx)
+           (ignore depth))
+  (print-unreadable-object (ctx stream :type t)
+    (print-display-name (context-display ctx) stream)
+    (write-string " " stream)
+    (princ (context-id ctx) stream)))
+
+
+(def-clx-class (visual (:constructor %make-visual)
+                       (:print-function print-visual)
+                       (:copier nil))
+  (id 0 :type resource-id)
+  (attributes nil :type list))
+
+
+(defun print-visual (visual stream depth)
+  (declare (type visual visual)
+           (ignore depth))
+  (print-unreadable-object (visual stream :type t)
+    (write-string "ID: " stream)
+    (princ (visual-id visual) stream)
+    (write-string " " stream)
+    (princ (visual-attributes visual) stream)))
+
+
+
+;;; Events.
+
+(defconstant +damaged+ #x8017)
+(defconstant +saved+ #x8018)
+(defconstant +window+ #x8019)
+(defconstant +pbuffer+ #x801a)
+
+
+(declare-event :glx-pbuffer-clobber
+  (card16 sequence)
+  (card16 event-type) ;; +DAMAGED+ or +SAVED+
+  (card16 draw-type) ;; +WINDOW+ or +PBUFFER+
+  (resource-id drawable)
+  ;; FIXME: (bitfield buffer-mask)
+  (card32 buffer-mask)
+  (card16 aux-buffer)
+  (card16 x y width height count))
+
+
+
+;;; Errors.
+
+(define-condition bad-context (request-error) ())
+(define-condition bad-context-state (request-error) ())
+(define-condition bad-drawable (request-error) ())
+(define-condition bad-pixmap (request-error) ())
+(define-condition bad-context-tag (request-error) ())
+(define-condition bad-current-window (request-error) ())
+(define-condition bad-render-request (request-error) ())
+(define-condition bad-large-request (request-error) ())
+(define-condition unsupported-private-request (request-error) ())
+(define-condition bad-fb-config (request-error) ())
+(define-condition bad-pbuffer (request-error) ())
+(define-condition bad-current-drawable (request-error) ())
+(define-condition bad-window (request-error) ())
+
+(define-error bad-context decode-core-error)
+(define-error bad-context-state decode-core-error)
+(define-error bad-drawable decode-core-error)
+(define-error bad-pixmap decode-core-error)
+(define-error bad-context-tag decode-core-error)
+(define-error bad-current-window decode-core-error)
+(define-error bad-render-request decode-core-error)
+(define-error bad-large-request decode-core-error)
+(define-error unsupported-private-request decode-core-error)
+(define-error bad-fb-config decode-core-error)
+(define-error bad-pbuffer decode-core-error)
+(define-error bad-current-drawable decode-core-error)
+(define-error bad-window decode-core-error)
+
+
+
+;;; Requests.
+
+
+(defun query-version (display)
+  (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+    ((data +query-version+)
+     (card32 1)
+     (card32 3))
+    (values
+     (card32-get 8)
+     (card32-get 12))))
+
+
+(defun query-server-string (display screen name)
+  "NAME is one of +VENDOR+, +VERSION+ or +EXTENSIONS+"
+  (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+    ((data +query-server-string+)
+     (card32 (or (position screen (display-roots display) :test #'eq) 0))
+     (card32 name))
+    (let* ((length (card32-get 12))
+           (bytes (sequence-get :format card8
+                                :result-type '(simple-array card8 (*))
+                                :index 32
+                                :length length)))
+      (declare (type (simple-array card8 (*)) bytes)
+               (type fixnum length))
+      (map-into (make-string (1- length)) #'code-char bytes))))
+
+
+(defun client-info (display)
+  ;; TODO: This should be invoked automatically when using this
+  ;; library in initialization stage.
+  ;; 
+  ;; TODO: No extensions supported yet.
+  ;; 
+  ;; *** Maybe the LENGTH field must be filled in some special way
+  ;;     (similar to data)?
+  (with-buffer-request (display (extension-opcode display "GLX"))
+    (data +client-info+)
+    (card32 4) ; length of the request
+    (card32 1) ; major
+    (card32 3) ; minor
+    (card32 0) ; n
+    ))
+
+
+;;; XXX: This looks like an internal thing.  Should name appropriately.
+(defun make-context (display)
+  (let ((ctx (%make-context :display display)))
+    (setf (context-id ctx)
+          (allocate-resource-id display ctx 'context))
+    ;; Prepare render request buffer.
+    ctx))
+
+
+(defun create-context (screen visual
+                       &optional
+                       (share-list 0)
+                       (is-direct nil))
+  "Do NOT use the direct mode, yet!"
+  (let* ((root (screen-root screen))
+         (display (drawable-display root))
+         (ctx (make-context display)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +create-context+)
+      (resource-id (context-id ctx))
+      (resource-id visual)
+      (card32 (or (position screen (display-roots display) :test #'eq) 0))
+      (resource-id share-list)
+      (boolean is-direct))
+    ctx))
+
+
+;;; TODO: Maybe make this var private to GLX-MAKE-CURRENT and GLX-GET-CURRENT-CONTEXT only?
+;;;
+(defvar *current-context* nil)
+
+
+(defun destroy-context (ctx)
+  (let ((id (context-id ctx))
+        (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +destroy-context+)
+      (resource-id id))
+    (deallocate-resource-id display id 'context)
+    (setf (context-id ctx) 0)
+    (when (eq ctx *current-context*)
+      (setf *current-context* nil))))
+
+
+(defun is-direct (ctx)
+  (let ((display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +is-direct+)
+         (resource-id (context-id ctx)))
+      (card8-get 8))))
+
+
+(defun query-context (ctx)
+  ;; TODO: What are the attribute types?
+  (let ((display (context-display ctx)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +query-context+)
+         (resource-id (context-id ctx)))
+      (let ((num-attributes (card32-get 8)))
+        ;; FIXME: Is this really so?
+        (declare (type fixnum num-attributes))
+        (loop
+           repeat num-attributes
+           for i fixnum upfrom 32 by 8
+           collecting (cons (card32-get i)
+                            (card32-get (+ i 4))))))))
+
+
+(defun get-drawable-attributes (drawable)
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +get-drawable-attributes+)
+         (drawable drawable))
+      (let ((num-attributes (card32-get 8)))
+        ;; FIXME: Is this really so?
+        (declare (type fixnum num-attributes))
+        (loop
+           repeat num-attributes
+           for i fixnum upfrom 32 by 8
+           collecting (cons (card32-get i)
+                            (card32-get (+ i 4))))))))
+
+
+;;; TODO: What is the idea behind passing drawable to this function?
+;;; Can a context be made current for different drawables at different
+;;; times?  (Man page on glXMakeCurrent says that context's viewport
+;;; is set to the size of drawable when creating; it does not change
+;;; afterwards.)
+;;; 
+(defun make-current (drawable ctx)
+  (let ((display (drawable-display drawable))
+        (old-tag (if *current-context* (context-tag *current-context*) 0)))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+        ((data +make-current+)
+         (resource-id (drawable-id drawable))
+         (resource-id (context-id ctx))
+         ;; *** CARD32 is really a CONTEXT-TAG
+         (card32 old-tag))
+      (let ((new-tag (card32-get 8)))
+        (setf (context-tag ctx) new-tag
+              (context-drawable ctx) drawable
+              (context-display ctx) display
+              *current-context* ctx)))))
+
+
+;;; FIXME: Decide how to represent and use these.
+(eval-when (:load-toplevel :compile-toplevel :execute)
+  (macrolet ((generate-config-properties ()
+               (let ((list '((:glx-visual visual-id)
+                             (:glx-class card32)
+                             (:glx-rgba bool32)
+                             (:glx-red-size card32)
+                             (:glx-green-size card32)
+                             (:glx-blue-size card32)
+                             (:glx-alpha-size card32)
+                             (:glx-accum-red-size card32)
+                             (:glx-accum-green-size card32)
+                             (:glx-accum-blue-size card32)
+                             (:glx-accum-alpha-size card32)
+                             (:glx-double-buffer bool32)
+                             (:glx-stereo bool32)
+                             (:glx-buffer-size card32)
+                             (:glx-depth-size card32)
+                             (:glx-stencil-size card32)
+                             (:glx-aux-buffers card32)
+                             (:glx-level int32))))
+                 `(progn
+                    ,@(loop for (symbol type) in list
+                         collect `(setf (get ',symbol 'visual-config-property-type) ',type))
+                    (defparameter *visual-config-properties*
+                      (map 'vector #'car ',list))
+                    (declaim (type simple-vector *visual-config-properties*))
+                    (deftype visual-config-property ()
+                      '(member ,@(mapcar #'car list)))))))
+    (generate-config-properties)))
+
+
+(defun make-visual (attributes)
+  (let ((id-cons (first attributes)))
+    (assert (eq :glx-visual (car id-cons))
+            (id-cons)
+            "GLX visual id must be first in attributes list!")
+    (%make-visual :id (cdr id-cons)
+                  :attributes (rest attributes))))
+
+
+(defun visual-attribute (visual attribute)
+  (assert (or (numberp attribute)
+              (find attribute *visual-config-properties*))
+          (attribute)
+          "~S is not a known GLX visual attribute." attribute)
+  (cdr (assoc attribute (visual-attributes visual))))
+
+
+;;; TODO: Make this return nice structured objects with field values of correct type.
+;;; FIXME: Looks like every other result is corrupted.
+(defun get-visual-configs (screen)
+  (let ((display (drawable-display (screen-root screen))))
+    (with-buffer-request-and-reply (display (extension-opcode display "GLX") nil)
+      ((data +get-visual-configs+)
+       (card32 (or (position screen (display-roots display) :test #'eq) 0)))
+      (let* ((num-visuals (card32-get 8))
+             (num-properties (card32-get 12))
+             (num-ordered (length *visual-config-properties*)))
+        ;; FIXME: Is this really so?
+        (declare (type fixnum num-ordered num-visuals num-properties))
+        (loop
+           with index fixnum = 28
+           repeat num-visuals
+           collecting (make-visual
+                       (nconc (when (<= num-ordered num-properties)
+                                (map 'list #'(lambda (property)
+                                               (cons property (card32-get (incf index 4))))
+                                     *visual-config-properties*))
+                              (when (< num-ordered num-properties)
+                                (loop repeat (/ (- num-properties num-ordered) 2)
+                                   collecting (cons (card32-get (incf index 4))
+                                                    (card32-get (incf index 4))))))))))))
+
+
+(defun choose-visual (screen attributes)
+  "ATTRIBUTES is a list of desired attributes for a visual.  The elements may be
+either a symbol, which means that the boolean attribute with that name must be true; or
+it can be a list of the form: (attribute-name value &optional (test '<=)) which means that
+the attribute named attribute-name must satisfy the test when applied to the given value and
+attribute's value in visual.
+Example: '(:glx-rgba (:glx-alpha-size 4) :glx-double-buffer (:glx-class 4 =)."
+  ;; TODO: Add type checks
+  ;;
+  ;; TODO: This function checks only supplied attributes; should check
+  ;; all attributes, with default for boolean type being false, and
+  ;; for number types zero.
+  ;; 
+  ;; TODO: Make this smarter, like the docstring says, instead of
+  ;; parrotting the inflexible C API.
+  ;; 
+  (flet ((visual-matches-p (visual attributes)
+           (dolist (attribute attributes t)
+             (etypecase attribute
+               (symbol (not (null (visual-attribute visual attribute))))
+               (cons (<= (second attribute) (visual-attribute visual (car attribute))))))))
+    (let* ((visuals (get-visual-configs screen))
+           (candidates (loop
+                          for visual in visuals
+                          when (visual-matches-p visual attributes)
+                          collect visual))
+           (result (first candidates)))
+    
+      (dolist (candidate (rest candidates))
+        ;; Visuals with glx-class 3 (pseudo-color) and 4 (true-color)
+        ;; are preferred over glx-class 2 (static-color) and 5 (direct-color).
+        (let ((class (visual-attribute candidate :glx-class)))
+          (when (or (= class 3)
+                    (= class 4))
+            (setf result candidate))))
+      result)))
+
+
+(defun render ()
+  (declare (optimize (debug 3)))
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx))
+         (rbuf (context-rbuf ctx))
+         (index (context-index ctx)))
+    (declare (type buffer-bytes rbuf)
+             (type array-index index))
+    (when (< 8 index)
+      (with-display (display)
+        ;; Flush display's buffer first so we don't get messed up with X requests.
+        (buffer-flush display)
+        ;; First, update the Render request fields.
+        (aset-card8 (extension-opcode display "GLX") rbuf 0)
+        (aset-card8 1 rbuf 1)
+        (aset-card16 (ceiling index 4) rbuf 2)
+        (aset-card32 (context-tag ctx) rbuf 4)
+        ;; Then send the request.
+        (buffer-write rbuf display 0 (context-index ctx))
+        ;; Start filling from the beginning
+        (setf (context-index ctx) 8)))
+    (values)))
+
+
+(defun swap-buffers ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    ;; Make sure all rendering commands are sent away.
+    (glx:render)
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +swap-buffers+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx))
+      (resource-id (drawable-id (context-drawable ctx))))
+    (display-force-output display)))
+
+
+;;; FIXME: These two are more complicated than sending messages.  As I
+;;; understand it, wait-gl should inhibit any X requests until all GL
+;;; requests are sent...
+(defun wait-gl ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +wait-gl+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx)))))
+
+
+(defun wait-x ()
+  (assert (context-p *current-context*)
+          (*current-context*)
+          "~S is not a context." *current-context*)
+  (let* ((ctx *current-context*)
+         (display (context-display ctx)))
+    (with-buffer-request (display (extension-opcode display "GLX"))
+      (data +wait-x+)
+      ;; *** GLX_CONTEXT_TAG
+      (card32 (context-tag ctx)))))

--- a/extensions/randr.lisp
+++ b/extensions/randr.lisp
@@ -1,0 +1,1022 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: RandR Extension
+;;;   Created: 2014-11-17
+;;;    Author: Johannes Martinez <johannes.martinez@gmail.com>
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2014 by Johannes Martinez
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+(in-package :xlib)
+
+(export '(rr-query-version
+	  rr-get-screen-info
+	  rr-set-screen-config
+
+ 	  ;;  1.2
+
+	  rr-get-screen-size-range
+	  rr-set-screen-size
+	  rr-get-screen-resources
+	  rr-get-output-info 
+	  rr-list-output-properties
+	  rr-query-output-property
+	  rr-configure-output-property
+	  rr-change-output-property
+	  rr-delete-output-property
+	  rr-get-output-property
+	  rr-create-mode
+	  rr-destroy-mode
+	  rr-add-output-mode
+	  rr-delete-output-mode
+	  rr-get-crtc-info
+	  rr-get-crtc-gamma-size
+	  rr-get-crtc-gamma
+	  rr-set-crtc-gamma
+
+	  ;;  1.3
+	  
+	  rr-get-screen-resources-current
+	  rr-set-crtc-transform
+	  rr-get-crtc-transform
+	  rr-get-panning
+	  rr-set-panning
+	  rr-set-output-primary
+	  rr-get-output-primary
+
+	  ;;  1.4
+	  
+	  rr-get-providers
+	  rr-get-provider-info
+	  rr-set-provider-output-source
+	  rr-set-provider-offload-sink
+	  rr-list-provider-properties
+
+	  ;; mask related
+	  make-mode-flag-keys
+	  make-mode-flag-mask
+	  make-rr-select-mask
+	  make-rr-select-keys
+	  make-rotation-keys
+	  make-rotation-mask
+
+	  ;; struct related
+	  rr-panning-top
+	  rr-panning-left
+	  rr-panning-width
+	  rr-panning-height
+	  rr-panning-track-top
+	  rr-panning-track-left
+	  rr-panning-track-width
+	  rr-panning-track-height
+	  rr-panning-border-left
+	  rr-panning-border-top
+	  rr-panning-border-bottom
+	  rr-panning-border-right
+	  rr-panning
+	  make-rr-transform
+	  ))
+
+(define-extension "RANDR"
+  :events (:rr-screen-change-notify
+	   :rr-crtc-change-notify
+	   :rr-output-change-notify
+	   :rr-output-property-notify)
+  :errors (output
+	   crtc
+	   mode))
+
+(defun randr-opcode (display)
+  (extension-opcode display "RANDR"))
+
+
+(defconstant +rr-major+			1)
+(defconstant +rr-minor+			4)
+
+(defconstant  +rr-QueryVersion+         	0)
+  ;; we skip 1 to make old clients fail pretty immediately */
+  
+
+(defconstant  +rr-SetScreenConfig+	        2)
+(defconstant  +rr-OldScreenChangeSelectInput+	3) ;; 3 used to be ScreenChangeSelectInput; deprecated */
+  
+(defconstant  +rr-SelectInput+	        	4)
+(defconstant  +rr-GetScreenInfo+        	5)
+
+  ;; * V1.2 additions */
+  
+(defconstant  +rr-GetScreenSizeRange+	        6)
+(defconstant  +rr-SetScreenSize+	        7)
+(defconstant  +rr-GetScreenResources+	        8)
+(defconstant  +rr-GetOutputInfo+	        9)
+(defconstant  +rr-ListOutputProperties+        10)
+(defconstant  +rr-QueryOutputProperty+	       11)
+(defconstant  +rr-ConfigureOutputProperty+     12)
+(defconstant  +rr-ChangeOutputProperty+        13)
+(defconstant  +rr-DeleteOutputProperty+    14)
+(defconstant  +rr-GetOutputProperty+	    15)
+(defconstant  +rr-CreateMode+		    16)
+(defconstant  +rr-DestroyMode+		    17)
+(defconstant  +rr-AddOutputMode+	    18)
+(defconstant  +rr-DeleteOutputMode+	    19)
+(defconstant  +rr-GetCrtcInfo+		    20)
+(defconstant  +rr-SetCrtcConfig+	    21)
+(defconstant  +rr-GetCrtcGammaSize+	    22)
+(defconstant  +rr-GetCrtcGamma+	    23)
+(defconstant  +rr-SetCrtcGamma+	    24)
+
+  ;; /* V1.3 additions */
+  
+(defconstant  +rr-GetScreenResourcesCurrent+	25)
+(defconstant  +rr-SetCrtcTransform+	    26)
+(defconstant  +rr-GetCrtcTransform+	    27)
+(defconstant  +rr-GetPanning+		    28)
+(defconstant  +rr-SetPanning+		    29)
+(defconstant  +rr-SetOutputPrimary+	    30)
+(defconstant  +rr-GetOutputPrimary+	    31)
+
+  ;; 1.4 additions
+  
+
+(defconstant  +rr-GetProviders+	      32)
+(defconstant  +rr-GetProviderInfo+	      33)
+(defconstant  +rr-SetProviderOffloadSink+    34)
+(defconstant  +rr-SetProviderOutputSource+   35)
+(defconstant  +rr-ListProviderProperties+    36)
+(defconstant  +rr-QueryProviderProperty+     37)
+(defconstant  +rr-ConfigureProviderProperty+ 38)
+(defconstant  +rr-ChangeProviderProperty+    39)
+(defconstant  +rr-DeleteProviderProperty+    40)
+(defconstant  +rr-GetProviderProperty+	      41)
+
+;;; status returns
+  
+
+(defconstant +rr-config-status+ '#(:success :invalid-config-time :invalid-time :failed))
+(defconstant +rr-connection+ '#(:connected :disconnected :unknown-connection))
+
+;;; mask-vectors and types
+
+  ;; Rotation
+  
+
+(defconstant +rotation-mask-vector+
+  '#(:rotate-0 :rotate-90 :rotate-180 :rotate-270 :reflect-x :reflect-y))
+
+(deftype rotation-mask-class ()
+  '(member :rotate-0 :rotate-90 :rotate-180 :rotate-270 :reflect-x :reflect-y))
+
+(deftype rotation-mask ()
+  '(or mask16 (clx-list event-mask-class)))
+
+  ;; Select
+  
+
+(defconstant +rr-select-mask-vector+
+  '#(:screen-change-notify-mask :crtc-change-notify-mask :output-change-notify-mask :output-property-notify-mask))
+
+(deftype rr-select-mask-class ()
+  '(member :screen-change-notify-mask :crtc-change-notify-mask :output-change-notify-mask :output-property-notify-mask))
+
+(deftype rr-select-mask ()
+  '(or mask8 (clx-list rr-select-mask-class)))
+
+  ;; Mode-flag
+  
+
+(defconstant +mode-flag-mask-vector+
+  '#(:hsync-positive :hsync-negative :vsync-positive :vsync-negative :interlace :double-scan :csync 
+     :csync-positive :csync-negative :hskew-present :b-cast :pixel-multiplex :double-clock :clock-divide-by-2))
+
+(deftype mode-flag-mask-class () 
+  '(member :hsync-positive :hsync-negative :vsync-positive :vsync-negative :interlace :double-scan 
+    :csync :csync-positive :csync-negative :hskew-present :b-cast :pixel-multiplex :double-clock 
+    :clock-divide-by-2))
+
+(deftype mode-flag-mask ()
+  '(or mask32 (clx-list mode-flag-mask-class)))
+
+  ;; temporarily here since not in xrender.lisp
+  
+
+(defconstant +render-subpixel-order+
+  '#(:unknown :horizontal-RGB :horizontal-BGR :vertical-RGB :vertical-BGR :none))
+
+  ;; mask encode-decode functions
+
+  ;; (defun make-mode-flag-mask (key-list)
+  ;;   (encode-mask +mode-flag-mask-vector+ key-list 'mode-flag-mask))
+
+  ;; (defun make-mode-flag-keys (mode-flag-mask)
+  ;;   (declare (type mask32 mode-flag-mask))
+  ;;   (declare (clx-values (clx-list mode-flag-mask)))
+  ;;   (decode-mask +mode-flag-mask-vector+ mode-flag-mask))
+
+  ;; (defun make-rotation-mask (key-list)
+  ;;   (encode-mask +rotation-mask-vector+ key-list ))
+  
+
+
+(defmacro define-mask-fns (name mask-size mask-vector mask-type)
+  (let ((encode-fn (xintern 'make- name '-mask))
+	(decode-fn (xintern 'make- name '-keys))) 
+    `(progn
+       (defun ,encode-fn (key-list)
+	 (encode-mask ,mask-vector key-list ',mask-type))
+       (defun ,decode-fn (bit-mask)
+	 (declare (type ,mask-size bit-mask))
+	 (declare (clx-values (clx-list ,mask-type)))
+	 (decode-mask ,mask-vector bit-mask))
+       )))
+
+(define-mask-fns mode-flag card32 +mode-flag-mask-vector+ mode-flag-mask)
+(define-mask-fns rr-select card8 +rr-select-mask-vector+ rr-select-mask)
+(define-mask-fns rotation card16 +rotation-mask-vector+ rotation-mask)
+
+;; (defconstant  +RRTransformUnit		    (1L+ << 0))
+;; (defconstant  +RRTransformScaleUp	    (1L+ << 1))
+;; (defconstant  +RRTransformScaleDown	    (1L+ << 2))
+;; (defconstant  +RRTransformProjective	    (1L+ << 3))
+
+;; types
+
+(deftype size-id () 'card16)
+(deftype rr-mode () '(or null resource-id))
+(deftype output () 'resource-id)
+(deftype connection () '(or +connected+ +disconnected+ +unknown-connection+))
+
+;; structs
+
+(def-clx-class (screen-size (:constructor make-screen-size (width-in-pixels
+							    height-in-pixels
+							    width-in-mm
+							    height-in-mm)))
+  (width-in-pixels 0 :type card16)
+  (height-in-pixels 0 :type card16)
+  (width-in-mm 0 :type card16)
+  (height-in-mm 0 :type card16))
+
+(def-clx-class (rr-mode-info 
+		(:constructor make-rr-mode-info (id width height dot-clock
+						 h-sync-start h-sync-end h-sync-total h-sync-skew
+						 v-sync-start v-sync-end v-total name-length mode-flags)))
+  (id  0 :type card32)
+  (width  0 :type card16)
+  (height  0 :type card16)
+  (dot-clock  0 :type card32)
+  (h-sync-start  0 :type card16)
+  (h-sync-end  0 :type card16)
+  (h-sync-total  0 :type card16)
+  (h-sync-skew  0 :type card16)
+  (v-sync-start  0 :type card16)
+  (v-sync-end  0 :type card16)
+  (v-total  0 :type card16)
+  (name-length  0 :type card16)
+  (mode-flags  0 :type mode-flag-mask))
+
+
+(def-clx-class (rr-panning)
+  (left 0 :type card16)
+  (top 0 :type card16)
+  (width 0 :type card16)
+  (height 0 :type card16)
+  (track-left 0 :type card16)  
+  (track-top 0 :type card16)
+  (track-width 0 :type card16)
+  (track-height 0 :type card16)
+  (border-left 0 :type int16)
+  (border-top 0 :type int16)
+  (border-right 0 :type int16)
+  (border-bottom 0 :type int16))
+
+(def-clx-class (rr-transform ( :type vector) :named )
+  (x  0 :type card32)
+  (y  0 :type card32)
+  (z  0 :type card32)
+  (i 0 :type card32)
+  (j 0 :type card32)
+  (k 0 :type card32)
+  (d 0 :type card32)
+  (e 0 :type card32)
+  (f 0 :type card32))
+
+;; accessors
+;; fricken macroexpansions !!! figure it out!!
+
+(define-accessor rr-transform (36)
+  ((index) `(make-rr-transform :x (card32-get (index+ ,index 0))
+			       :y (card32-get (index+ ,index 4)) :z (card32-get (index+ ,index 8))
+			       :i (card32-get (index+ ,index 12)) :j (card32-get (index+ ,index 16))
+			       :k (card32-get (index+ ,index 20)) :d (card32-get (index+ ,index 24))
+			       :e (card32-get (index+ ,index 28)) :f (card32-get (index+ ,index 32))
+			       ))
+  ((index thing) `(sequence-put ,index ,thing :start 1)))
+
+;; (define-accessor rr-panning (24)
+;;   ((index) `(make-rr-panning :left (card16-get ,index)
+;; 			     :top (card16-get (index+ ,index 2))
+;; 			     :width (card16-get (index+ ,index 4))
+;; 			     :height (card16-get (index+ ,index 6))
+;; 			     :track-left (card16-get (index+ ,index 8))
+;; 			     :track-top (card16-get (index+ ,index 10))
+;; 			     :track-width (card16-get (index+ ,index 12))
+;; 			     :track-height (card16-get (index+ ,index 14))
+;; 			     :border-left (int16-get (index+ ,index 16))
+;; 			     :border-top (int16-get (index+ ,index 18))
+;; 			     :border-right (int16-get (index+ ,index 20))
+;; 			     :border-bottom (int16-get (index+ ,index 22))))
+;;   ;; put doesn't work
+;;   ((index thing)  `(progn ,`(write-card16 (index+ ,index 0)(rr-panning-left ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 2)(rr-panning-top ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 4)(rr-panning-width ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 6)(rr-panning-height ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 8)(rr-panning-track-left ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 10)(rr-panning-track-top ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 12)(rr-panning-track-width ,thing)) 
+;; 			  , `(write-card16 (index+ ,index 14)(rr-panning-track-height ,thing)) 
+;; 			  , `(write-int16 (index+ ,index 16)(rr-panning-border-left ,thing)) 
+;; 			  , `(write-int16 (index+ ,index 18)(rr-panning-border-top ,thing)) 
+;; 			  , `(write-int16 (index+ ,index 20)(rr-panning-border-right ,thing)) 
+;; 			  , `(write-int16(index+ ,index 22)(rr-panning-border-bottom ,thing)))
+;; 		       ))
+
+;; (defmacro pan-put ())
+
+(define-accessor rr-mode-info (32)
+  ((index)
+   `(make-rr-mode-info 
+     (card32-get ,index)
+     (card16-get (+ ,index 4))
+     (card16-get (+ ,index 6))
+     (card32-get (+ ,index 8))
+     (card16-get (+ ,index 12))
+     (card16-get (+ ,index 14))
+     (card16-get (+ ,index 16))					
+     (card16-get (+ ,index 18))
+     (card16-get (+ ,index 20))
+     (card16-get (+ ,index 22))
+     (card16-get (+ ,index 24))
+     (card16-get (+ ,index 26))
+     (card32-get (+ ,index 28)))) 
+  ((index thing)
+   `(progn (card32-put ,index (rr-mode-info-id ,thing))
+     (card16-put (index+ ,index 4) (rr-mode-info-width ,thing))
+     (card16-put (index+ ,index 6) (rr-mode-info-height ,thing))
+     (card32-put (index+ ,index 8) (rr-mode-info-dot-clock ,thing))
+     (card16-put (index+ ,index 12) (rr-mode-info-h-sync-start ,thing))
+     (card16-put (index+ ,index 14) (rr-mode-info-h-sync-end ,thing))
+     (card16-put (index+ ,index 16) (rr-mode-info-h-sync-total ,thing))
+     (card16-put (index+ ,index 18) (rr-mode-info-h-sync-skew ,thing))
+     (card16-put (index+ ,index 20) (rr-mode-info-v-sync-start ,thing))
+     (card16-put (index+ ,index 22) (rr-mode-info-v-sync-end ,thing))
+     (card16-put (index+ ,index 24) (rr-mode-info-v-total ,thing))
+     (card16-put (index+ ,index 26) (rr-mode-info-name-length ,thing))
+     (card32-put (index+ ,index 28) (rr-mode-info-mode-flags ,thing))
+     )))
+
+;; x-events
+
+;; test!!
+
+(declare-event :rr-screen-change-notify
+  ((data (member8 +rotation-mask-vector+)))
+  (card16 sequence)
+  (card32 timestamp config-timestamp)
+;  (card32 config-timestamp)
+  (window root-window request-window)
+ ; (window request-window)
+  (card16 size-id sub-pixel-order width height width-in-mm height-in-mm))
+
+(declare-event :rr-crtc-change-notify
+  ((data (member8 +rotation-mask-vector+)))
+  (card16 sequence)
+  (card32 timestamp)
+  (window request-window)
+  (card32 crtc)
+  (card32 mode)
+  (card16 rotation)
+  (pad16)
+  (int16 x y)
+  (card16 width height))
+
+(declare-event :rr-output-change-notify
+  (card16 sequence)
+  (card32 timestamp config-timestamp)
+  (window request-window)
+  (card32 output crtc mode)
+  (card16 rotation)
+  (card8 connection)
+  (card8 sub-pixel-order))
+
+(declare-event :rr-output-property-notify
+  (card16 sequence)
+  (window window)
+  (card32 output atom timestamp)
+  (boolean state)
+  )
+
+;; x-requests
+
+(defun rr-query-version (display)
+"Returns version MAJOR and MINOR from server."
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (32))
+				 ((data +rr-QueryVersion+)
+				  (card32 +rr-major+)
+				  (card32 +rr-minor+))
+    (values
+     (card32-get 8)
+     (card32-get 12))))
+
+(defun rr-set-screen-config (window timestamp conf-timestamp size-id rotation refresh)
+  "Sets the current screen to which the given window belongs.  Timestamps are obtained from rr-get-screen-info.  Rotation can be a list of rotation keys or a rotation mask.  Returns timestamp, config timestamp, the root window of the screen and sub-pixel order."
+  (let ((display (window-display window))
+	(rot-mask (if (consp rotation) 
+		      (make-rotation-mask rotation) 
+		      rotation)))
+    (declare (type display display)
+	     (type window window)
+	     (type card16 size-id rot-mask refresh)
+	     (type card32 timestamp conf-timestamp))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (16 32))
+				   ((data +rr-SetScreenConfig+)
+				    (window window)
+				    (card32 timestamp)
+				    (card32 conf-timestamp)
+				    (card16 size-id)
+				    (card16 rot-mask)
+				    (card16 refresh)
+				    (pad16))
+      (values
+       (member8-vector-get 1 +rr-config-status+)
+       (card32-get 8)  ;; timestamp
+       (card32-get 12) ;; config timestamp
+       (window-get 16) ;; root window
+       (member16-vector-get 20 +render-subpixel-order+) ;; sub pixel order
+       ))))
+
+(defun rr-select-input (window enable)
+"Enables event reception for given window.  Enable may be a select-mask or list of select-keys "
+  (let ((display (window-display window))
+	(select-mask (if (consp enable) (make-rr-select-mask enable) enable)))
+    (declare (type display display)
+	     (type window window)
+	     (type card16 select-mask))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-selectinput+)
+      (window window)
+      (card16 select-mask)
+      (pad16))))
+
+(defun rr-get-screen-info (window &optional (result-type 'list))
+"Returns rotations, root-window, timestamp, config-timestamp, current-size-id, current rotation, current rate, a list of screen-size structures, and last a sequence of refresh-rates"
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-GetScreenInfo+ )
+				    (window window))
+      (let ((num-screens (card16-get 20))
+	      (num-rates (card16-get 28))
+	    (rates-location 0))
+	(declare (type fixnum rates-location num-rates))
+	  (values
+	   (make-rotation-keys (card16-get 1)) ; possible rotations, using card16, not card8 from spec.
+	   (window-get 8) ;root window
+	   (card32-get 12) ;timestamp
+	   (card32-get 16) ;config-timestamp
+	   (card16-get 22) ;size-id
+	   (make-rotation-keys (card16-get 24)) ;current rotation
+	   (card16-get 26) ; current rate
+	   (loop :for x fixnum :from 1 :to num-screens
+		 :for offset fixnum := 32 :then (+ offset 8)
+		 :collect (make-screen-size (card16-get offset)
+					    (card16-get (index+ offset 2))
+					    (card16-get (index+ offset 4))
+					    (card16-get (index+ offset 6)))
+		 :finally (setf rates-location (+ offset 8 2)))
+	   (sequence-get :format card16 :length num-rates :index rates-location :result-type result-type))))))
+
+
+;; Version 1.2
+
+(defun rr-get-screen-size-range (window &optional (result-type 'list))
+"Returns a sequence of minimum width, minimum height, max width, max height."
+  (let ((display (window-display window)))
+   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (16))
+				  ((data +rr-getscreensizerange+)
+				   (window window))
+     (values
+      (sequence-get :format card16 :length 4 :index 8 :result-type result-type)))))
+
+
+;; doesn't work, asynchronous match error. set screen config works fine.
+
+(defun rr-set-screen-size (window width height width-mm height-mm)
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window)
+	     (type card16 width height)
+	     (type card32 width-mm height-mm))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-setscreensize+)
+      (window window)
+      (card16 width)
+      (card16 height)
+      (card32 width-mm)
+      (card32 height-mm))))
+
+(defun rr-get-screen-resources (window &optional (result-type 'list))
+  ""
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-getscreenresources+)
+				    (window window))
+      (let* ((num-crtcs (card16-get 16))	     
+	     (num-outputs (card16-get 18))
+	     (output-start (index+ +replysize+ (index* num-crtcs 4)))	     
+	     (num-modeinfos (card16-get 20))
+	     (name-bytes (card16-get 22))
+	     (mode-start (index+ output-start (index* num-outputs 4)))
+	     (name-start (index+ mode-start (index* num-modeinfos 32))))
+	(values
+	 (card32-get 8)			; timestamp
+	 (card32-get 12)		; config-timestamp
+	 (sequence-get :format card32 :result-type result-type :index 32 :length num-crtcs)
+	 (sequence-get :format card32 :result-type result-type :index output-start :length num-outputs)
+	 (loop :for i fixnum :from 1 :to num-modeinfos
+	       :for offset fixnum := mode-start :then (+ offset 32)
+	       :collect (rr-mode-info-get offset))
+	 (string-get name-bytes name-start))
+	))))
+
+
+
+(defun rr-get-output-info (display output config-timestamp &optional (result-type 'list))
+"FIXME: indexes might be off, name not decoded properly"
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-getoutputinfo+)
+				  (card32 output)
+				  (card32 config-timestamp))
+    (let* ((num-crtcs (card16-get 26))
+	  (num-modes (card16-get 28))
+	  (num-clones (card16-get 32))
+	  (name-length (card16-get 34))
+	  (crtc-start 26)
+	  (mode-start (index+ crtc-start (index* num-crtcs 4)))
+	  (clone-start (index+ mode-start (index* num-modes 4)))
+	  (name-start (index+ clone-start (index* num-clones 4))))
+      (values
+	(member8-vector-get 1 +rr-config-status+)
+	(card32-get 8)  ; timestamp
+	(card32-get 12) ; current connected crtc
+	(card32-get 16) ; width in mm
+	(card32-get 20) ; height in mm
+	(member8-vector-get 24 +rr-connection+)
+	(member8-vector-get 25 +render-subpixel-order+)  ; sub-pixel-order
+	(sequence-get :result-type result-type :length num-crtcs :index 26)
+	(card16-get 30)
+	(sequence-get :result-type result-type :length num-modes :index mode-start)
+	(sequence-get :result-type result-type :length num-clones :index clone-start)
+	;(string-get name-length name-start )
+	(sequence-get :result-type 'string :format card16 :length name-length :index name-start :transform #'code-char)) 
+)))
+
+(defun rr-list-output-properties (display output &optional (result-type 'list))
+"Returns a list of atom properties for given display. ?keep it simple and return id's or atom-names?"
+  (declare (type display display) 
+	   (type card32 output))
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-listoutputproperties+)
+				  (card32 output))
+    (let ((num-atoms (card16-get 8)))
+      (values
+       (sequence-get :format card32 :result-type result-type :length num-atoms :index +replysize+ :transform #'(lambda (id) (atom-name display id)))))))
+
+(defun rr-query-output-property (display output atom &optional (result-type 'list))
+"Querys the current properties of an atom.  Atom may be referenced by either id or keyword"
+  (let ((atom (if (typep atom 'keyword) (find-atom display atom) atom)))
+    (declare (type display display)
+	     (type card32 atom))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-queryoutputproperty+)
+				    (card32 output)
+				    (card32 atom))
+      (values
+       (boolean-get 8)  ; pending
+       (boolean-get 9)  ; range
+       (boolean-get 10) ; immutable
+       (sequence-get :result-type result-type :index +replysize+ :length (card32-get 4))))))
+
+(defun rr-configure-output-property (display output atom value-list &optional (pending nil) (range nil))
+  "Atom can be specified by either id or keyword"
+  (let ((atom (if (typep atom 'keyword) (find-atom display atom) atom))
+	(seq (coerce value-list 'vector)))
+    (declare (type display display)
+	     (type card32 output value-list)
+	     (type boolean pending range))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-configureoutputproperty+)
+      (card32 output)
+      (card32 atom)
+      (boolean pending range)
+      ((sequence :format card32) seq))))
+
+;; Spec says type is not interpreted, what use?  shit, are certain property types tied to certain formats?  change if necessary after get-output-property
+
+;; FIXME asynchronous match error
+(defun rr-change-output-property (display output atom mode data &optional  (atom-type 0) )
+"Mode may be 0-replace 1-prepend 2-append. atom-type is obtained by calling rr-get-output-property "
+  (let ((atom (if (typep atom 'keyword) (find-atom display atom) atom))
+	(data-length (length data))
+	(seq (coerce data 'vector))
+	)
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-changeoutputproperty+)
+      (card32 output)
+      (card32 atom)
+      (card32 atom-type)
+      (card8 32) ; should we be concerned about extra bytes for small values?		
+      (card8 mode)
+      (pad16)
+      (card32 data-length)
+      ((sequence :format card32) seq))))
+
+(defun rr-delete-output-property (display output property)
+  ""
+  (let ((atom (if (typep property 'keyword) (find-atom display property) property)))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-deleteoutputproperty+)
+      (card32 output)
+      (card32 atom))))
+
+(defun rr-get-output-property (display output property  &optional (type 0) (delete 0) (pending 0) (result-type 'list))
+  ""
+  (let ((atom (if (typep property 'keyword) (find-atom display property) property)))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-getoutputproperty+)
+				    (card32 output)
+				    (card32 atom)
+				    (card32 type)
+				    (card32 0) ; long-offset
+				    (card32 0) ; long-length
+				    (card8 delete)
+				    (card8 pending)
+				    (pad16))
+      (let* ((bytes-after (card32-get 12))
+	     (value-length (card32-get 16))
+	     (byte-format (unless (eql value-length 0) 
+			    (if (eql bytes-after value-length)
+				'card8
+				(if (eql 2 (/ bytes-after value-length))
+				    'card16
+				    'card32)))))
+	
+	(values
+	 (card32-get 8)			; type
+	 value-length
+	 (when (not (eql value-length 0)) 
+	   (case byte-format 
+	     ('card8 ( sequence-get :format card8 :index +replysize+ :length value-length :result-type result-type))
+	     ('card16 ( sequence-get :format card16 :index +replysize+ :length value-length :result-type result-type))
+	     ('card32 ( sequence-get :format card32 :index +replysize+ :length value-length :result-type result-type))))
+	 )
+	))))
+
+
+
+(defun rr-create-mode (window mode-info name)
+"FIXME"
+  (let ((display (window-display window)))
+    (declare (type display display)
+	     (type window window)
+	     (type rr-mode-info mode-info)
+	     (type string name))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-createmode+)
+				    (window window)
+				    (progn (rr-mode-info-put 8 mode-info)
+					   (string-put 40 name)))
+      (values
+       (card32-get 8) ; mode
+       ))))
+
+(defun rr-destroy-mode (display mode)
+""
+ (with-buffer-request (display (randr-opcode display))
+   (data +rr-destroymode+)
+   (card32 mode)))
+
+(defun rr-add-output-mode (display output mode)
+""
+ (with-buffer-request (display (randr-opcode display))
+   (data +rr-addoutputmode+)
+   (card32 output)
+   (card32 mode)))
+
+(defun rr-delete-output-mode (display output mode)
+""
+ (with-buffer-request (display (randr-opcode display))
+   (data +rr-deleteoutputmode+)
+   (card32 output)
+   (card32 mode)))
+
+(defun rr-get-crtc-info (display crtc config-timestamp &optional (result-type 'list))
+  ""
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-getcrtcinfo+)
+				  (card32 crtc)
+				  (card32 config-timestamp))
+    (let* ((num-outputs (card16-get 28))
+	   (pos-outputs (card16-get 30))
+	   (pos-start (index+ +replysize+ (index* num-outputs 4))))
+      (values
+       (member8-vector-get 1 +rr-config-status+)
+       (card32-get 8)                                   ; timestamp
+       (int16-get 12)					; x
+       (int16-get 14)					; y
+       (card16-get 16)					; width
+       (card16-get 18)					; height
+       (card32-get 20)					; mode
+       (make-rotation-keys (card16-get 24) )  ; current
+       (make-rotation-keys (card16-get 26))  ; possible
+       (sequence-get :result-type result-type :index +replysize+ :length num-outputs)
+       (sequence-get :result-type result-type :index pos-start :length pos-outputs)))))
+
+(defun rr-set-crtc-config (display crtc timestamp config-timestamp x y mode rotation output-list)
+"Rotation can be a rotation mask or list of rotation keys."
+  (let ((rot-mask (if (consp rotation) (make-rotation-mask rotation) rotation))
+	(seq (coerce output-list 'vector)))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-setcrtcconfig+)
+				    (card32 crtc)
+				    (card32 timestamp)
+				    (card32 config-timestamp)
+				    (card16 x)
+				    (card16 y)
+				    (card32 mode)
+				    (card16 rot-mask)
+				    (pad16)
+				    ((sequence :format card32) seq))
+      (values
+       (member8-vector-get 1 +rr-config-status+)
+       (card32-get 8) ; new timestamp
+       ))))
+
+(defun rr-get-crtc-gamma-size (display crtc)
+"Used to determine length of gamma ramps to submit in set-crtc-gamma"
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-getcrtcgammasize+)
+				  (card32 crtc))
+    (values
+     (card16-get 8))))
+
+(defun rr-get-crtc-gamma (display crtc &optional (result-type 'list))
+  "Get current gamma ramps, returns 3 sequences for red, green, blue."
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-getcrtcgamma+)
+				  (card32 crtc))
+    (let* ((size (card16-get 8))
+	  (green-start (index+ +replysize+ (index* 2 size)))
+	  (blue-start (index+ green-start (index* 2 size)))) 
+      (values
+       (sequence-get :format card16 :length size :index +replysize+ :result-type result-type)
+       (sequence-get :format card16 :length size :index green-start :result-type result-type)
+       (sequence-get :format card16 :length size :index blue-start :result-type result-type)))))
+
+(defun rr-set-crtc-gamma (display crtc red green blue)
+  "gamma values must be lists and must be the same length as returned by get-crtc-gamma-size"
+  (declare (type cons red green blue))
+  (let ((size (length blue))
+	(seq (coerce (append red green blue) 'vector)))
+    (declare (type vector seq)
+	     (type display display)
+	     (type card16 size))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-setcrtcgamma+)
+      (card32 crtc)
+      (card16 size)
+      (pad16)     
+      ((sequence :format card16) seq))))
+
+;; version 1.3
+
+
+ (defun rr-get-screen-resources-current (window &optional (result-type 'list ))
+   "Unlike RRGetScreenResources, this merely returns the current configuration, and does not poll for hardware changes."
+   (let ((display (window-display window)))
+     (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				    ((data +rr-getscreenresourcescurrent+)
+				     (window window))
+       (let* ((num-crtcs (card16-get 16))	     
+	     (num-outputs (card16-get 18))
+	     (output-start (index+ +replysize+ (index* num-crtcs 4)))	     
+	     (num-modeinfos (card16-get 20))
+	     (name-bytes (card16-get 22))
+	     (mode-start (index+ output-start (index* num-outputs 4)))
+	     (name-start (index+ mode-start (index* num-modeinfos 32))))
+	(values
+	 (card32-get 8)			; timestamp
+	 (card32-get 12)		; config-timestamp
+	 (sequence-get :format card32 :result-type result-type :index 32 :length num-crtcs)
+	 (sequence-get :format card32 :result-type result-type :index output-start :length num-outputs)
+	 (loop :for i fixnum :from 1 :to num-modeinfos
+	       :for offset fixnum := mode-start :then (+ offset 32)
+	       :collect (rr-mode-info-get offset))
+	 (string-get name-bytes name-start))))))
+
+
+;; (defun rr-set-crtc-transform (display crtc transform &optional ( filter-name nil) ( filter-parameters nil))
+;;   "FIXME:Transfrom may be a list or vector of length 9.  ?perhaps allow length 6?"
+;;   (let ((seq (if filter-parameters (coerce filter-parameters 'vector) nil ))
+;; 	(param-length (length filter-parameters))
+;; 	(name-length (length filter-name)))
+;;     (declare ;(type vector seq)
+;; 	     (type card16 param-length)
+;; 	     (type display display)
+;; 	     (type string filter-name))
+;;     (with-buffer-request (display (randr-opcode display))
+;;       (data +rr-setcrtctransform+)
+;;       (card32 crtc)
+;;       (card16 param-length)
+;;       (pad16)
+;;       (rr-transform transform)
+;;       (card16 name-length)
+;;       (pad16)
+;;       (string filter-name)
+;; ;      ((sequence :format card32) seq)
+		     
+      
+;;       ;((sequence :format card32) seq)
+;;       )))
+
+
+(defun rr-get-crtc-transform (display crtc &optional (result-type 'list))
+  ""
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+  				 ((data +rr-getcrtctransform+)
+				  (card32 crtc))
+    (let* ((pend-name        (card16-get 88))
+	   (pend-num-params (card16-get 90))
+	   (pad-pend (- 4 (mod pend-name 4)))
+	   (pad-pend-start (index+ 96 pend-name pad-pend))
+	   (cur-name         (card16-get 92))
+	   (cur-num-params   (card16-get 94))
+	   (pad-cur (- 4 (mod cur-name 4)))
+	   (cur-name-start (index+ pad-pend-start (index* 4 pend-num-params)))
+	   (cur-param-start (index+ cur-name-start cur-name pad-cur))
+	   )
+      (declare (type card16 pend-name cur-name))
+      (values
+       (rr-transform-get 8)
+       ;(sequence-get :result-type result-type :length 9 :index 8)
+       (card8-get 44)
+       (sequence-get :result-type result-type :length 9 :index 48)
+       (string-get pend-name 96)
+       (sequence-get :result-type result-type :length pend-num-params :index pad-pend-start)
+       (string-get cur-name cur-name-start)
+       (sequence-get :result-type result-type :length cur-num-params :index cur-param-start )
+  ))))
+
+
+;; (defun rr-get-panning (display crtc)
+;;   ""
+;;   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+;;   				 ((data +rr-getpanning+)
+;; 				  (card32 crtc))
+;;     (values
+;;      (member8-vector-get 1 +rr-config-status+)
+;;      (card32-get 8) ; timestamp
+;;      (rr-panning-get 12)
+;; 					;(sequence-get :length 8 :format card16 :index 12 :result-type result-type)
+;;      ;(sequence-get :length 4 :format int16 :index 28 :result-type result-type)
+;;      )))
+
+
+
+;; (defun rr-set-panning (display crtc timestamp rr-panning)
+;;   ""
+;;   (declare (type rr-panning rr-panning))
+;;   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+;;   				 ((data +rr-setpanning+)
+;; 				  (card32 crtc)
+;; 				  (card32 timestamp)
+;; 				 ;				  (progn ()
+;; 				  (rr-panning rr-panning))
+    
+;;     (values
+;;      (member8-vector-get 1 +rr-config-status+)
+;; 					;  (card32-get 8) ; new timestamp
+;;      )))
+
+(defun rr-set-output-primary (window output)
+  ""
+  (let ((display (window-display window)))
+    (with-buffer-request (display (randr-opcode display))
+      (data +rr-setoutputprimary+)
+      (window window)
+      (card32 output))))
+
+(defun rr-get-output-primary (window)
+  ""
+  (let ((display (window-display window)))
+    (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				   ((data +rr-getoutputprimary+)
+				    (window window))
+      (values
+       (card32-get 8)
+       ))))
+
+
+
+
+(defun rr-get-providers (window)
+""
+  (let ((display (window-display window)))
+      (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				     ((data +rr-getproviders+)
+				      (window window))
+	(values
+	 (card32-get 8)  ; timestamp	 
+	 (card16-get 12) ; num providers  
+	; (string-get 1256 14) ; checking if this is supposed to return anything besides just num
+	; (sequence-get :index 46 :length (card16-get 12) :format card8 :result-type 'list )
+	 ))))
+
+(defun rr-get-provider-info (display provider config-timestamp)
+""
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-getproviderinfo+)
+				  (card32 provider)
+				  (card32 config-timestamp))
+    (values
+     (card32-get 8)  ;timestamp
+     (card32-get 12) ; capabilities
+     (card16-get 16) ; num crtcs
+     (card16-get 18) ; num outputs
+     (card16-get 20) ; num associated providers
+     (string-get (card16-get 22) 56))))
+
+(defun rr-set-provider-output-source (display provider source-provider config-timestamp)
+  (with-buffer-request (display (randr-opcode display))
+    (data +rr-setprovideroutputsource+)
+    (card32 provider)
+    (card32 source-provider)
+    (card32 config-timestamp)))
+
+(defun rr-set-provider-offload-sink (display provider sink-provider config-timestamp)
+  (with-buffer-request (display (randr-opcode display))
+    (data +rr-setprovideroffloadsink+)
+    (card32 provider)
+    (card32 sink-provider)
+    (card32 config-timestamp)))
+
+
+
+(defun rr-list-provider-properties (display provider)
+""
+  (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+				 ((data +rr-listproviderproperties+)
+				  (card32 provider))
+    (values
+     (card32-get 4)
+     (card16-get 8))))
+
+
+;; (defun rr-query-provider-property (display provider atom)
+;; "untested"
+;;   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+;; 				 ((data +rr-queryproviderproperty+)
+;; 				  (card32 provider)
+;; 				  (card32 atom))
+;;     (values
+;;      (boolean-get 8)
+;;      (boolean-get 9)
+;;      (boolean-get 10))))
+
+;; (defun  (display)
+;; ""
+;;   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+;; 				 ((data))
+;;     (values
+;;      ())))
+
+;; (defun  (display)
+;; ""
+;;   (with-buffer-request-and-reply (display (randr-opcode display) nil :sizes (8 16 32))
+;; 				 ((data))
+;;     (values
+;;      ())))
+

--- a/extensions/screensaver.lisp
+++ b/extensions/screensaver.lisp
@@ -1,0 +1,69 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: X11 MIT Screensaver extension
+;;;   Created: 2005-08-28 01:41
+;;;    Author: Istvan Marko <mi-clx@kismala.com>
+;;; ---------------------------------------------------------------------------
+;;;  (c) copyright 2005 by Istvan Marko
+
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+;;; Description:
+;;;
+;;; This is a partial interface to the MIT-SCREEN-SAVER
+;;; extension. Only the ScreenSaverQueryVersion and
+;;; ScreenSaverQueryInfo requests are implemented because I couldn't
+;;; think of a use for the rest. In fact, the only use I see for this
+;;; extension is screen-saver-get-idle which provides and easy way to
+;;; find out how long has it been since the last keyboard or mouse
+;;; activity.
+
+;;; A description of this extension can be found at
+;;; doc/hardcopy/saver/saver.PS.gz in the X11 distribution.
+
+(in-package :xlib)
+
+(export '(screen-saver-query-version
+	  screen-saver-query-info
+	  screen-saver-get-idle)
+        :xlib)
+
+(define-extension "MIT-SCREEN-SAVER")
+
+(defun screen-saver-query-version (display)
+  (with-buffer-request-and-reply (display (extension-opcode display "MIT-SCREEN-SAVER")
+                                          nil)
+    ((data 0)
+     (card8 1) ;client major version
+     (card8 0) ;client minor version
+     (card16 0)) ; unused
+    (values
+     (card16-get 8) ; server major version
+     (card16-get 10)))) ; server minor version
+
+(defun screen-saver-query-info (display drawable)
+  (with-buffer-request-and-reply (display (extension-opcode display "MIT-SCREEN-SAVER")
+                                          nil)
+    ((data 1)
+     (drawable drawable))
+    (values
+     (card8-get 1) ; state: off, on, disabled
+     (window-get 8) ; screen saver window if active
+     (card32-get 12) ; tilorsince msecs. how soon before the screen saver kicks in or how long has it been active
+     (card32-get 16) ; idle msecs
+     (card8-get 24)))) ; kind: Blanked, Internal, External
+
+(defun screen-saver-get-idle (display drawable)
+  "How long has it been since the last keyboard or mouse input"
+   (multiple-value-bind (state window tilorsince idle kind) (screen-saver-query-info display drawable)
+     (declare (ignore state window kind))
+     (values idle tilorsince)))

--- a/extensions/shape.lisp
+++ b/extensions/shape.lisp
@@ -1,0 +1,192 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: X11 Shape extension
+;;;   Created: 1999-05-14 11:31
+;;;    Author: Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
+;;; ---------------------------------------------------------------------------
+;;;  (c) copyright 1999 by Gilbert Baumann
+
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+;;; Use xc/doc/hardcopy/Xext/shape.PS.gz obtainable from e.g.
+;;  ftp://ftp.xfree86.org/pub/XFree86/current/untarred/xc/hardcopy/Xext/shape.PS.gz
+
+(in-package :xlib)
+
+(export '(shape-query-version
+          shape-rectangles
+          shape-mask
+          shape-combine
+          shape-offset
+          shape-query-extents
+          shape-select-input
+          shape-input-selected-p
+          shape-get-rectangles)
+        :xlib)
+
+(define-extension "SHAPE"
+    :events (:shape-notify))
+
+(declare-event :shape-notify
+               ((data (member8 :bounding :clip)) kind) ;shape kind
+               (card16 sequence)
+               (window (window event-window)) ;affected window
+               (int16 x)                ;extents
+               (int16 y)
+               (card16 width)
+               (card16 height)
+               ((or null card32) time)  ;timestamp
+               (boolean shaped-p))
+
+(defun encode-shape-kind (kind)
+  (ecase kind
+    (:bounding 0)
+    (:clip 1)))
+
+(defun encode-shape-operation (operation)
+  (ecase operation
+    (:set 0)
+    (:union 1)
+    (:interset 2)
+    (:subtract 3)
+    (:invert 4)))
+
+(defun encode-shape-rectangle-ordering (ordering)
+  (ecase ordering
+    ((:unsorted :un-sorted nil) 0)
+    ((:y-sorted) 1)
+    ((:yx-sorted) 2)
+    ((:yx-banded) 3)))
+
+(defun shape-query-version (display)
+  (with-buffer-request-and-reply (display (extension-opcode display "SHAPE")
+                                          nil :sizes 16)
+    ((data 0))
+    (values
+     (card16-get 8)
+     (card16-get 10))))
+
+(defun shape-rectangles (window rectangles
+                                &key (kind :bounding)
+                                (x-offset 0)
+                                (y-offset 0)
+                                (operation :set)
+                                (ordering :unsorted))
+  (let* ((display (xlib:window-display window)))
+    (with-buffer-request (display (extension-opcode display "SHAPE"))
+      (data 1)
+      (card8 (encode-shape-operation operation))
+      (card8 (encode-shape-kind kind))
+      (card8 (encode-shape-rectangle-ordering ordering))
+      (card8 0)                         ;unused
+      (window window)
+      (int16 x-offset)
+      (int16 y-offset)
+      ((sequence :format int16) rectangles))))
+
+(defun shape-mask (window pixmap
+                          &key (kind :bounding)
+                          (x-offset 0)
+                          (y-offset 0)
+                          (operation :set))
+  (let* ((display (xlib:window-display window)))
+    (with-buffer-request (display (extension-opcode display "SHAPE"))
+      (data 2)
+      (card8 (encode-shape-operation operation))
+      (card8 (encode-shape-kind kind))
+      (card16 0)                        ;unused
+      (window window)
+      (int16 x-offset)
+      (int16 y-offset)
+      ((or pixmap (member :none)) pixmap))))
+
+(defun shape-combine (window source-window
+                             &key (kind :bounding)
+                             (source-kind :bounding)
+                             (x-offset 0)
+                             (y-offset 0)
+                             (operation :set))
+  (let* ((display (xlib:window-display window)))
+    (with-buffer-request (display (extension-opcode display "SHAPE"))
+      (data 3)
+      (card8 (encode-shape-operation operation))
+      (card8 (encode-shape-kind kind))
+      (card8 (encode-shape-kind source-kind))
+      (card8 0)                         ;unused
+      (window window)
+      (int16 x-offset)
+      (int16 y-offset)
+      (window source-window))))
+
+(defun shape-offset (window &key (kind :bounding) (x-offset 0) (y-offset 0))
+  (let* ((display (xlib:window-display window)))
+    (with-buffer-request (display (extension-opcode display "SHAPE"))
+      (data 4)
+      (card8 (encode-shape-kind kind))
+      (card8 0) (card8 0) (card8 0)     ;unused
+      (window window)
+      (int16 x-offset)
+      (int16 y-offset))))
+
+(defun shape-query-extents (window)
+  (let* ((display (xlib:window-display window)))
+    (with-buffer-request-and-reply (display (extension-opcode display "SHAPE")
+                                            nil :sizes (8 16 32))
+      ((data 5)
+       (window window))
+      (values
+       (boolean-get 8)                  ;bounding shaped
+       (boolean-get 9)                  ;clip shaped
+       (int16-get 12)                   ;bounding shape extents x
+       (int16-get 14)                   ;bounding shape extents y
+       (card16-get 16)                  ;bounding shape extents width
+       (card16-get 18)                  ;bounding shape extents height
+       (int16-get 20)                   ;clip shape extents x
+       (int16-get 22)                   ;clip shape extents y
+       (card16-get 24)                  ;clip shape extents width
+       (card16-get 26)))))              ;clip shape extents height
+
+(defun shape-select-input (window selected-p)
+  (let* ((display (window-display window)))
+    (with-buffer-request (display (extension-opcode display "SHAPE"))
+      (data 6)
+      (window window)
+      (boolean selected-p)) ))
+
+(defun shape-input-selected-p (window)
+  (let* ((display (window-display window)))
+    (with-buffer-request-and-reply (display (extension-opcode display "SHAPE")
+                                            nil :sizes (8))
+      ((data 7)                         ;also wrong in documentation
+       (window window))
+      (boolean-get 1))))
+
+(defun shape-get-rectangles (window &optional (kind :bounding)
+                                    (result-type 'list))
+  (let* ((display (window-display window)))
+    (with-buffer-request-and-reply (display (extension-opcode display "SHAPE")
+                                            nil :sizes (8 16 32))
+      ((data 8)                         ;this was wrong in the specification
+       (window window)
+       (card8 (ecase kind
+                (:bounding 0)
+                (:clip 1))))
+      (values
+       (sequence-get :length (print (* 4 (card32-get 8)))
+                     :result-type result-type
+                     :format int16
+                     :index +replysize+)
+       (ecase (card8-get 1)
+         (0 :unsorted)
+         (1 :y-sorted)
+         (2 :yx-sorted)
+         (3 :yx-banded) )))))

--- a/extensions/xc-misc.lisp
+++ b/extensions/xc-misc.lisp
@@ -1,0 +1,87 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: XC Misc Extension
+;;;   Created: 2014-11-17
+;;;    Author: Johannes Martinez <johannes.martinez@gmail.com>
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2014 by Johannes Martinez
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+(in-package :xlib)
+
+(export '(xc-get-version
+	  xc-get-xid-range
+	  xc-get-xid-list
+	  ))
+
+(define-extension "XC-MISC")
+
+
+;; version
+(defconstant +xc-major+               1)
+(defconstant +xc-minor+               1)
+
+
+;; xc major opcode
+(defun xc-opcode (display)
+  (extension-opcode display "XC-MISC"))
+
+;; xc minor opcodes
+
+(defconstant +xc-get-version+         0)
+(defconstant +xc-get-xid-range+       1)
+(defconstant +xc-get-xid-list+        2)
+
+;; x requests
+
+(defun xc-get-version (display)
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (xc-opcode display) nil :sizes (16))
+				 ((data +xc-get-version+)
+				  (card16 +xc-major+)
+				  (card16 +xc-minor+))
+    (values
+     (card16-get 8)
+     (card16-get 10))))
+
+(defun xc-get-xid-range (display)
+  "returns a range of available resource IDs for the client issuing the request."
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (xc-opcode display) nil :sizes (32))
+				 ((data +xc-get-xid-range+))
+    (values
+     (card32-get 8)
+     (card32-get 12))))
+
+(defun xc-get-xid-list (display count &optional (result-type 'list))
+  "This request returns a sequence of individual resource IDs in ids. Count is the number 
+of resource IDs requested. The number returned may be smaller than the number requested."
+  (declare (type display display)
+	   (type card32 count))
+  (with-buffer-request-and-reply (display (xc-opcode display) nil :sizes (32))
+				 ((data +xc-get-xid-list+)
+				  (card32 count))
+    (let ((num (card32-get 8)))
+      (values
+       (sequence-get :format card32 :result-type result-type 
+		     :length num :index 32)))))
+
+
+
+
+
+
+
+
+
+

--- a/extensions/xinerama.lisp
+++ b/extensions/xinerama.lisp
@@ -1,0 +1,93 @@
+;;; -*- Mode: Lisp -*-
+;;;
+;;; Copyright (C) 2008, Julian Stecklina
+;;;
+;;;   ((
+;;;    ))     This file is COFFEEWARE. As long as you retain this notice
+;;;  |   |o)  you can do whatever you want with this code. If you think,
+;;;  |___|jgs it's worth it, you may buy the author a coffee in return.
+;;;
+;;; Description:
+;;;
+;;; This is an implementation of the XINERAMA extension. It does not
+;;; include the obsolete PanoramiX calls.
+
+(defpackage "XLIB.XINERAMA"
+  (:use "COMMON-LISP" "XLIB")
+  (:nicknames "XINERAMA")
+  (:import-from "XLIB"
+		"WITH-BUFFER-REQUEST"
+		"WITH-BUFFER-REQUEST-AND-REPLY"
+		"DATA"
+		"BOOLEAN" "BOOLEAN-GET"
+		"CARD8" "CARD8-GET"
+		"CARD16" "CARD16-GET"
+		"CARD32" "CARD32-GET"
+		"INT16" "INT16-GET")
+  (:export "SCREEN-INFO"
+           "SCREEN-INFO-NUMBER"
+           "SCREEN-INFO-X"
+           "SCREEN-INFO-Y"
+           "SCREEN-INFO-WIDTH"
+           "SCREEN-INFO-HEIGHT"
+           "XINERAMA-QUERY-VERSION"
+           "XINERAMA-IS-ACTIVE"
+           "XINERAMA-QUERY-SCREENS"))
+(in-package "XINERAMA")
+
+(define-extension "XINERAMA")
+
+(defun xinerama-opcode (display)
+  (extension-opcode display "XINERAMA"))
+
+(defconstant +major-version+ 1)
+(defconstant +minor-version+ 1)
+
+(defconstant +get-version+ 0)
+(defconstant +get-state+ 1)
+(defconstant +get-screen-count+ 2)
+(defconstant +get-screen-size+ 3)
+(defconstant +is-active+ 4)
+(defconstant +query-screens+ 5)
+
+(defstruct screen-info
+  (number 0 :type (unsigned-byte 32))
+  (x 0 :type (signed-byte 16))
+  (y 0 :type (signed-byte 16))
+  (width 0 :type (unsigned-byte 16))
+  (height 0 :type (unsigned-byte 16)))
+
+(defun xinerama-query-version (display)
+  (with-buffer-request-and-reply (display (xinerama-opcode display) nil)
+    ((data +get-version+)
+     (card8 +major-version+)
+     (card8 +minor-version+))
+    (values
+     (card16-get 8)                     ; server major version
+     (card16-get 10))))                 ; server minor version
+
+(defun xinerama-is-active (display)
+  "Returns T, iff Xinerama is supported and active."
+  (with-buffer-request-and-reply (display (xinerama-opcode display) nil)
+    ((data +is-active+))
+    (values
+     ;; XCB says this is actually a CARD32, but why?!
+     (boolean-get 8))))
+
+(defun xinerama-query-screens (display)
+  "Returns a list of screen-info structures."
+  (with-buffer-request-and-reply (display (xinerama-opcode display) nil)
+    ((data +query-screens+))
+    (values
+     (loop
+        with index = 32
+        for number from 0 below (card32-get 8)
+        collect (prog1
+                    (make-screen-info :number number
+                                      :x (int16-get index)
+                                      :y (int16-get (+ index 2))
+                                      :width (card16-get (+ index 4))
+                                      :height (card16-get (+ index 6)))
+                  (incf index 8))))))
+
+;;; EOF

--- a/extensions/xrender.lisp
+++ b/extensions/xrender.lisp
@@ -1,0 +1,1179 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: The X Render Extension
+;;;   Created: 2002-08-03
+;;;    Author: Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
+;;;       $Id: xrender.lisp,v 1.5 2004/12/06 11:48:57 csr21 Exp $
+;;; ---------------------------------------------------------------------------
+;;;
+;;; (c) copyright 2002, 2003 by Gilbert Baumann
+;;; (c) copyright 2002 by Christian Sunesson
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+;;; NOTE: we need to watch maximum request sizes and somehow work
+;;; around them. Sometimes e.g. in AddGlyphs this is not possible,
+;;; which is a design failure.
+
+;;; TODO
+
+;; - some request are still to be implemented at all.
+;;   + Can they not wait? Xrender seems to be in flux as the specification
+;;     isn't even conforming to the acctual protocol. However backwards
+;;     wierd that sound. --noss
+
+;; - we need to invent something for the color values of e.g. 
+;;   fill-rectangles; I would prefer some generic functions, so that
+;;   we later can map CLIM design directly to colors.
+
+;; - we want some conviencene function to turn graphics contexts into
+;;   render pictures. --GB 2002-08-21
+
+;; - also: uniform-alpha-picture display alpha-value
+;;         uniform-color-picture display red green blue
+;;   --GB 2002-08-21
+
+;; - maybe we should aim for a higher level interface to
+;;   color-trapzoids and color-triangles and offer a low level [raw]
+;;   interface also for high performance apps?
+
+;; - Write tests.
+
+;;;; API issues
+
+;; - On one hand we want convenience functions like RENDER-TRIANGLE or
+;;   WITH-UNIFORM-COLOR-PICTURE. On the other hand if you are up to
+;;   write a full rasterization library you obviously want high
+;;   performance entry points as RENDER-TRIANGLES-1.
+
+;; - We want to extend XLIB:COLOR into something with alpha channel.
+;;   How to name it?
+
+;; - WITH-UNIFORM-COLOR-PICTURE (var picture r g b &optional alpha) &body body
+;;
+;;   Example:
+;;   (WITH-UNIFORM-COLOR-PICTURE (color dest 1.0 1.0 0.0)
+;;     (RENDER-TRIANGLE dest color ...))
+
+;; - Pose the filter and the transform slots of a picture.
+
+;; - Also introduce a PICTURE-DEFAULT-MASK-FORMAT?
+
+;; - COPY-PICTURE?
+
+;; - WITH-PICTURE-OPTIONS ?
+;;
+;;   (WITH-PICTURE-OPTIONS (pic :repeat :on) ...)
+
+;; - WITH-PICTURE ?
+;;
+;;   (WITH-PICTURE (picture drawable ...) ...)
+
+;;
+
+(in-package :xlib)
+
+;; Beginning to collect the external interface for documentation.
+(export '(render-create-picture
+	  render-free-picture
+	  
+	  render-create-glyph-set
+	  render-reference-glyph-set
+	  render-free-glyph-set
+	  
+	  render-add-glyph
+	  render-add-glyph-from-picture
+	  render-free-glyph
+          render-fill-rectangle
+
+	  picture-format-display 
+	  picture-format-id
+	  picture-format-type
+	  picture-format-depth
+	  picture-format-red-byte
+	  picture-format-green-byte
+	  picture-format-blue-byte
+	  picture-format-alpha-byte
+	  picture-format-colormap
+
+          ;; picture object
+          picture-repeat
+          picture-alpha-map
+          picture-alpha-x-origin
+          picture-alpha-y-origin
+          picture-clip-x-origin
+          picture-clip-y-origin
+          picture-clip-mask
+          picture-graphics-exposures
+          picture-subwindow-mode
+          picture-poly-edge
+          picture-poly-mode
+          picture-dither
+          picture-component-alpha
+          picture-drawable
+
+          find-matching-picture-formats
+          find-window-picture-format
+          render-free-picture
+          render-free-glyph-set
+          render-query-version
+          ;; render-query-picture-formats
+          render-fill-rectangle
+          render-triangles
+          render-trapezoids
+          render-composite
+          render-create-glyph-set
+          render-reference-glyph-set
+          render-composite-glyphs
+          render-add-glyph
+          render-add-glyph-from-picture
+          render-free-glyphs))
+
+(pushnew :clx-ext-render *features*)
+
+(define-extension "RENDER")
+
+;;;; Request constants
+
+;; Note: Although version numbers are given render.h where the request
+;; numbers are defined, render-query-version returns 0.0 all displays
+;; i tested. --GB 2004-07-21
+
+(defconstant +X-RenderQueryVersion+ 0)                  ;done
+(defconstant +X-RenderQueryPictFormats+ 1)
+(defconstant +X-RenderQueryPictIndexValues+ 2)          ;0.7
+(defconstant +X-RenderQueryDithers+ 3)
+(defconstant +X-RenderCreatePicture+ 4)                 ;done
+(defconstant +X-RenderChangePicture+ 5)                 ;done
+(defconstant +X-RenderSetPictureClipRectangles+ 6)      ;done
+(defconstant +X-RenderFreePicture+ 7)                   ;done
+(defconstant +X-RenderComposite+ 8)                     ;we need better arglist
+(defconstant +X-RenderScale+ 9)
+(defconstant +X-RenderTrapezoids+ 10)                   ;low-level done
+(defconstant +X-RenderTriangles+ 11)                    ;low-level done
+(defconstant +X-RenderTriStrip+ 12)
+(defconstant +X-RenderTriFan+ 13)
+(defconstant +X-RenderColorTrapezoids+ 14)              ;nyi in X server, not mentioned in renderproto.h
+(defconstant +X-RenderColorTriangles+ 15)               ;nyi in X server, not mentioned in renderproto.h
+(defconstant +X-RenderTransform+ 16)                    ;commented out in render.h
+(defconstant +X-RenderCreateGlyphSet+ 17)               ;done
+(defconstant +X-RenderReferenceGlyphSet+ 18)            ;done
+(defconstant +X-RenderFreeGlyphSet+ 19)                 ;done
+(defconstant +X-RenderAddGlyphs+ 20)                    ;done, untested
+(defconstant +X-RenderAddGlyphsFromPicture+ 21)         ;done, untested
+(defconstant +X-RenderFreeGlyphs+ 22)                   ;done, untested
+(defconstant +X-RenderCompositeGlyphs8+ 23)             ;done
+(defconstant +X-RenderCompositeGlyphs16+ 24)            ;done
+(defconstant +X-RenderCompositeGlyphs32+ 25)            ;done
+
+;; >= 0.1
+  
+(defconstant +X-RenderFillRectangles+ 26)               ;single rectangle version done
+
+;; >= 0.5
+
+(defconstant +X-RenderCreateCursor+ 27)
+
+;; >= 0.6
+
+(defconstant +X-RenderSetPictureTransform+ 28)          ;I don't understand what this one should do.
+(defconstant +X-RenderQueryFilters+ 29)                 ;seems to be there on server side
+                                                        ; some guts of its implementation there.
+(defconstant +X-RenderSetPictureFilter+ 30)
+(defconstant +X-RenderCreateAnimCursor+ 31)             ;What has render to do with cursors?
+
+;;;;
+
+;; Sanity measures:
+
+;; We do away with the distinction between pict-format and
+;; picture-format-info. That is we cache picture-format-infos.
+
+(defstruct picture-format
+  display 
+  (id   0 :type (unsigned-byte 29))
+  type
+  depth
+  red-byte
+  green-byte
+  blue-byte
+  alpha-byte
+  colormap)
+
+(def-clx-class (glyph-set (:copier nil)
+                        )
+  (id 0 :type resource-id)
+  (display nil :type (or null display))
+  (plist nil :type list)                ; Extension hook
+  (format))
+
+(defstruct render-info
+  major-version
+  minor-version
+  picture-formats)
+
+(defun display-render-info (display)
+  (getf (xlib:display-plist display) 'render-info))
+
+(defun (setf display-render-info) (new-value display)
+  (setf (getf (xlib:display-plist display) 'render-info)
+        new-value))
+
+(defun ensure-render-initialized (display)
+  "Ensures that the RENDER extension is initialized. Should be called
+by every function, which attempts to generate RENDER requests."
+  ;; xxx locking?
+  (unless (display-render-info display)
+    (let ((q (make-render-info)))
+      (multiple-value-bind (maj min) (render-query-version display)
+        (setf (render-info-major-version q) maj
+              (render-info-minor-version q) min)
+        (setf (render-info-picture-formats q)
+              (make-hash-table :test #'eql))
+        (dolist (pf (render-query-picture-formats display))
+          (setf (gethash (picture-format-id pf) (render-info-picture-formats q))
+                pf))
+        (setf (display-render-info display) q)))))
+
+(defun find-matching-picture-formats
+    (display
+     &key depth-min depth-max depth
+          red-min red-max red
+          green-min green-max green
+          blue-min blue-max blue
+          alpha-min alpha-max alpha
+          type
+          colormap)
+  ;;
+  (ensure-render-initialized display)
+  (let ((res nil))
+    (maphash (lambda (k f)
+               (declare (ignore k))
+               (when (and
+                      (or (null type) (eql (picture-format-type f) type))
+                      (or (null colormap)  (eql (picture-format-colormap f) colormap))
+                      ;; min
+                      (or (null depth-min) (>= (picture-format-depth f) depth-min))
+                      (or (null red-min)   (>= (byte-size (picture-format-red-byte f)) red-min))
+                      (or (null green-min) (>= (byte-size (picture-format-green-byte f)) green-min))
+                      (or (null blue-min)  (>= (byte-size (picture-format-blue-byte f)) blue-min))
+                      (or (null alpha-min) (>= (byte-size (picture-format-alpha-byte f)) alpha-min))
+                      ;; max
+                      (or (null depth-max) (<= (picture-format-depth f) depth-max))
+                      (or (null red-max)   (<= (byte-size (picture-format-red-byte f)) red-max))
+                      (or (null green-max) (<= (byte-size (picture-format-green-byte f)) green-max))
+                      (or (null blue-max)  (<= (byte-size (picture-format-blue-byte f)) blue-max))
+                      (or (null alpha-max) (<= (byte-size (picture-format-alpha-byte f)) alpha-max))
+                      ;; match
+                      (or (null depth)     (= (picture-format-depth f) depth))
+                      (or (null red)       (= (byte-size (picture-format-red-byte f)) red))
+                      (or (null green)     (= (byte-size (picture-format-green-byte f)) green))
+                      (or (null blue)      (= (byte-size (picture-format-blue-byte f)) blue))
+                      (or (null alpha)     (= (byte-size (picture-format-alpha-byte f)) alpha)))
+                 (pushnew f res)))
+             (render-info-picture-formats
+              (display-render-info display)))
+    res))
+
+(defun find-window-picture-format (window)
+  "Find the picture format which matches the given window."
+  (let* ((vi (window-visual-info window))
+         (display (window-display window)))
+    (ensure-render-initialized display)
+    (case (visual-info-class vi)
+      ((:true-color)
+       (maphash (lambda (k f)
+                  (declare (ignore k))
+                  (when (and (eql (picture-format-type f) :direct)
+                             (eql (picture-format-depth f) (drawable-depth window))
+                             (eql (dpb -1 (picture-format-red-byte f) 0)
+                                  (visual-info-red-mask vi))
+                             (eql (dpb -1 (picture-format-green-byte f) 0)
+                                  (visual-info-green-mask vi))
+                             (eql (dpb -1 (picture-format-blue-byte f) 0)
+                                  (visual-info-blue-mask vi))
+                             (eql (byte-size (picture-format-alpha-byte f)) 0))
+                    (return-from find-window-picture-format f)))
+                (render-info-picture-formats
+                 (display-render-info display))))
+      (t
+       ))))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (define-accessor picture (32)
+    ((index) index :blip)
+    ((index thing) `(resource-id-put ,index (picture-id ,thing))))
+  (define-accessor glyph-set (32)
+    ((index) index :blip)
+    ((index thing) `(resource-id-put ,index (glyph-set-id ,thing)))))
+
+;;; picture format
+
+(defmethod print-object ((object picture-format) stream)
+  (let ((abbrev
+         (with-output-to-string (bag)
+           ;; build an abbreviated representation of the format
+           (let ((bytes (sort (list (cons "r" (picture-format-red-byte object))
+                                    (cons "g" (picture-format-green-byte object))
+                                    (cons "b" (picture-format-blue-byte object))
+                                    (cons "a" (picture-format-alpha-byte object)))
+                              #'>
+                              :key #'(lambda (x) (byte-position (cdr x))))))
+             (dolist (k bytes)
+               (unless (zerop (byte-size (cdr k)))
+                 (format bag " ~A~D" (car k) (byte-size (cdr k)))))))))
+    (print-unreadable-object (object stream :type t :identity nil)
+      (format stream "~D ~S ~S ~S~A"
+              (picture-format-id object)
+              (picture-format-colormap object)
+              (picture-format-depth object)
+              (picture-format-type object) abbrev))))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (define-accessor picture-format (32)
+    ((index)       `(gethash (read-card32 ,index)
+                     (render-info-picture-formats (display-render-info .display.))))
+    ((index thing) `(write-card32 ,index (picture-format-id ,thing))))
+  (define-accessor render-op (8)
+    ((index) `(member8-get ,index
+               :clear :src :dst :over :over-reverse :in :in-reverse
+               :out :out-reverse :atop :atop-reverse :xor :add :saturate
+               '#:undefined-pict-op-Eh '#:undefined-pict-op-Fh
+               :disjoint-clear :disjoint-src :disjoint-dst :disjoint-over
+               :disjoint-over-reverse :disjoint-in :disjoint-in-reverse
+               :disjoint-out :disjoint-out-reverse :disjoint-atop
+               :disjoint-atop-reverse :disjoint-xor
+               '#:undefined-pict-op-1Ch '#:undefined-pict-op-1Dh
+               '#:undefined-pict-op-1Eh '#:undefined-pict-op-1Fh
+               :conjoint-clear :conjoint-src :conjoint-dst :conjoint-over
+               :conjoint-over-reverse :conjoint-in :conjoint-in-reverse
+               :conjoint-out :conjoint-out-reverse :conjoint-atop
+               :conjoint-atop-reverse :conjoint-xor))
+    ((index thing) `(member8-put ,index ,thing
+                     :clear :src :dst :over :over-reverse :in :in-reverse
+                     :out :out-reverse :atop :atop-reverse :xor :add :saturate
+                     '#:undefined-pict-op-Eh '#:undefined-pict-op-Fh
+                     :disjoint-clear :disjoint-src :disjoint-dst :disjoint-over
+                     :disjoint-over-reverse :disjoint-in :disjoint-in-reverse
+                     :disjoint-out :disjoint-out-reverse :disjoint-atop
+                     :disjoint-atop-reverse :disjoint-xor
+                     '#:undefined-pict-op-1Ch '#:undefined-pict-op-1Dh
+                     '#:undefined-pict-op-1Eh '#:undefined-pict-op-1Fh
+                     :conjoint-clear :conjoint-src :conjoint-dst :conjoint-over
+                     :conjoint-over-reverse :conjoint-in :conjoint-in-reverse
+                     :conjoint-out :conjoint-out-reverse :conjoint-atop
+                     :conjoint-atop-reverse :conjoint-xor)))
+  (deftype render-op ()
+    '(member :clear :src :dst :over :over-reverse :in :in-reverse
+      :out :out-reverse :atop :atop-reverse :xor :add :saturate
+      :disjoint-clear :disjoint-src :disjoint-dst :disjoint-over
+      :disjoint-over-reverse :disjoint-in :disjoint-in-reverse
+      :disjoint-out :disjoint-out-reverse :disjoint-atop
+      :disjoint-atop-reverse :disjoint-xor
+      :conjoint-clear :conjoint-src :conjoint-dst :conjoint-over
+      :conjoint-over-reverse :conjoint-in :conjoint-in-reverse
+      :conjoint-out :conjoint-out-reverse :conjoint-atop
+      :conjoint-atop-reverse :conjoint-xor)))
+
+;; Now these pictures objects are like graphics contexts. I was about
+;; to introduce a synchronous mode, realizing that the RENDER protocol
+;; provides no provision to actually query a picture object's values. 
+;; *sigh*
+
+(def-clx-class (picture (:copier nil))
+  (id 0 :type resource-id)
+  (display nil :type (or null display))
+  (plist nil :type list)                ; Extension hook
+  (format)
+  (%changed-p)
+  (%server-values)
+  (%values)
+  (%drawable))
+
+(defun picture-drawable (picture)
+  (picture-%drawable picture))
+
+;; xx make id, display, format readonly
+
+(defun %render-change-picture-clip-rectangles (picture rectangles)
+  "Dont call me, use (SETF PICTURE-CLIP-MASK) instead."
+  (declare (optimize (speed 0)))
+  (let ((display (picture-display picture)))
+    (ensure-render-initialized display)
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderSetPictureClipRectangles+)
+      (picture picture)
+      (int16    (picture-clip-x-origin picture))
+      (int16    (picture-clip-y-origin picture))
+      ((sequence :format int16) rectangles))))
+
+(macrolet ((foo (&rest specs)
+             `(progn
+               ,@(loop for (type slot default) in specs
+                       for index from 0
+                       collect
+                       `(progn
+                         (defun ,(xintern 'picture- slot) (picture)
+                           (aref (picture-%values picture) ,index))
+                         (defun (setf ,(xintern 'picture- slot)) (new-value picture)
+                           (setf (picture-%changed-p picture) t)
+                           (setf (aref (picture-%values picture) ,index) new-value))))
+    
+               (defun synchronise-picture-state (picture)
+                 (when (picture-%changed-p picture)
+                   (let ((display (picture-display picture)))
+                     (ensure-render-initialized display)
+                     (with-buffer-request (display (extension-opcode display "RENDER"))
+                       (data +X-RenderChangePicture+)
+                       (picture picture)
+                       (mask
+                        ,@(loop for (type slot default) in specs
+                                for index from 0
+                                collect
+                                `(,type (and
+                                         ,(cond ((eql slot 'clip-mask)
+                                                 `(not (typep (aref (picture-%values picture) ,index)
+                                                        'sequence)))
+                                                (t
+                                                 't))
+                                         (not (eq (aref (picture-%values picture) ,index)
+                                                  (aref (picture-%server-values picture) ,index)))
+                                         (setf (aref (picture-%server-values picture) ,index)
+                                          (aref (picture-%values picture) ,index))))))))
+                   ,(let ((index (position 'clip-mask specs :key #'second)))
+                         `(unless (eql (aref (picture-%values picture) ,index)
+                                   (aref (picture-%server-values picture)
+                                    ,index))
+                           (%render-change-picture-clip-rectangles
+                            picture (aref (picture-%values picture) ,index))
+                           (setf (aref (picture-%server-values picture) ,index)
+                                 (aref (picture-%values picture) ,index))))
+
+                   (setf (picture-%changed-p picture) nil)))
+
+               (defun render-create-picture
+                   (drawable
+                    &key format
+                         (picture (make-picture :display (drawable-display drawable)))
+                         ,@(loop for (type slot default-value) in specs
+                                 collect (cond ((eql slot 'clip-mask)
+                                                `(clip-mask :none))
+                                               (t
+                                                slot)))
+                         )
+                 ;; xxx also offer to give a colormap instead of a picture-format
+                 ;; values!
+                 (let ((display (drawable-display drawable)))
+                   (ensure-render-initialized display)
+                   (unless format
+                     ;; xxx check for drawable being a window
+                     (setf format (find-window-picture-format drawable)))
+                   (let ((pid (allocate-resource-id display picture 'picture)))
+                     (setf (picture-id picture) pid)
+                     (with-buffer-request (display (extension-opcode display "RENDER"))
+                       (data +X-RenderCreatePicture+)
+                       (resource-id pid)
+                       (drawable drawable)
+                       (picture-format format)
+                       (mask
+                        ,@(loop for (type slot default) in specs
+                                collect
+                                (cond ((eql slot 'clip-mask)
+                                       (list type `(and
+                                                    (not (typep clip-mask 'sequence))
+                                                    clip-mask)))
+                                      (t
+                                       (list type slot)))))))
+                   (when (typep clip-mask 'sequence)
+                     (%render-change-picture-clip-rectangles picture clip-mask))
+                   (setf (picture-format picture) format)
+                   (setf (picture-%server-values picture)
+                         (vector ,@(loop for (type slot default) in specs
+                                         collect
+                                         `(or ,slot ,default))))
+                   (setf (picture-%values picture) (copy-seq (picture-%server-values picture)))
+                   (setf (picture-%drawable picture) drawable)
+                   picture))
+    
+               (defconstant +picture-state-length+
+                 ,(length specs)) )))
+
+  (foo ((member :off :on) repeat                                          :off)
+       ((or (member :none) picture) alpha-map                             :none)
+       (int16 alpha-x-origin                                              0)
+       (int16 alpha-y-origin                                              0)
+       (int16 clip-x-origin                                               0)
+       (int16 clip-y-origin                                               0)
+       ;; ### Now that is not correct is it?:
+       ((or (member :none) pixmap) clip-mask                              :none)
+       ((member :off :on) graphics-exposures                              :on)
+       ((member :clip-by-children :include-inferiors) subwindow-mode      :clip-by-children)
+       ((member :sharp :smooth) poly-edge                                 :smooth)
+       ((member :precise :imprecise) poly-mode                            :precise)
+       ((or (member :none) #||xatom||#) dither                            :none)
+       ((member :off :on) component-alpha                                 :off)))
+
+(defun render-free-picture (picture)
+  (let ((display (picture-display picture)))
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderFreePicture+)
+      (picture  picture))))
+
+(defun render-free-glyph-set (glyph-set)
+  (let ((display (glyph-set-display glyph-set)))
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderFreeGlyphSet+)
+      (glyph-set  glyph-set))))
+
+(defun render-query-version (display)
+  (with-buffer-request-and-reply (display (extension-opcode display "RENDER") nil)
+    ((data +X-RenderQueryVersion+)
+     (card32 0)
+     (card32 1))
+    (values
+     (card32-get 8)
+     (card32-get 12) )))
+
+(defun render-query-picture-formats (display)
+  (with-buffer-request-and-reply (display (extension-opcode display "RENDER") nil)
+    ((data +X-RenderQueryPictFormats+))
+    (let ((n-picture-formats (card32-get 8))
+          (n-screens      (card32-get 12))
+          (n-depths       (card32-get 16))
+          (n-visuals      (card32-get 20))
+          (n-subpixel     (card32-get 24)))
+      (declare (ignore n-screens n-depths n-visuals n-subpixel))
+      (loop for i below n-picture-formats
+            collect
+            (let ((off (+ (* 8 4)
+                          (* i 28))))   ;size of picture-format-info
+              (make-picture-format
+               :display display
+               :id         (card32-get (+ off 0))
+               :type       (member8-get (+ off 4) :indexed :direct)
+               :depth      (card8-get   (+ off 5))
+               :red-byte   (byte (integer-length (card16-get (+ off 10)))
+                                 (card16-get (+ off 8)))
+               :green-byte (byte (integer-length (card16-get (+ off 14)))
+                                 (card16-get (+ off 12)))
+               :blue-byte  (byte (integer-length (card16-get (+ off 18)))
+                                 (card16-get (+ off 16)))
+               :alpha-byte (byte (integer-length (card16-get (+ off 22)))
+                                 (card16-get (+ off 20)))
+               :colormap   (let ((cmid (card32-get (+ off 24))))
+                             (unless (zerop cmid)
+                               (lookup-colormap display cmid)))))))))
+
+(defun render-fill-rectangle (picture op color x1 y1 w h)
+  (let ((display (picture-display picture)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state picture)
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderFillRectangles+)
+      (render-op op)
+      (pad8 0)
+      (pad16 0)
+      (resource-id (picture-id picture))
+      (card16 (elt color 0)) (card16 (elt color 1)) (card16 (elt color 2)) (card16 (elt color 3))
+      (int16 x1) (int16 y1) (card16 w) (card16 h))))
+
+;; fill rectangles, colors.
+
+(defun render-triangles (picture op source src-x src-y format coord-sequence)
+  ;; For performance reasons we do a special typecase on (simple-array
+  ;; (unsigned-byte 32) (*)), so that it'll be possible to have high
+  ;; performance rasters.
+  (macrolet ((guts ()
+               '(let ((display (picture-display picture)))
+                 (synchronise-picture-state picture)
+                 (synchronise-picture-state source)
+                 (labels ((funk (x) (ash x 16)))
+                   (with-buffer-request (display (extension-opcode display "RENDER"))
+                     (data +X-RenderTriangles+)
+                     (render-op op)
+                     (pad8 0)
+                     (pad16 0)
+                     (resource-id (picture-id source))
+                     (resource-id (picture-id picture))
+                     (picture-format format)
+                     (int16 src-x)
+                     (int16 src-y)
+                     ((sequence :format int32 :transform #'funk) coord-sequence))))))
+    (typecase coord-sequence
+      ((simple-array (unsigned-byte 32) (*))
+       (locally
+           (declare (type (simple-array (unsigned-byte 32) (*)) coord-sequence))
+         (guts)))
+      (t
+       (guts)))))
+
+#||
+(defun render-set-picture-transform (picture mxx mxy dx mxy myy dy &optional (mwx 0) (mwy 0) (dw 1))
+  ...)
+||#
+
+(defun render-set-picture-transform (picture a b c d e f p q r)
+  (let ((display (picture-display picture)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state picture)
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderSetPictureTransform+)
+      #|
+      (card8 0) ;; render-op op)                    ;op
+      (card8 0)                         ;pad
+      (card16 0)                        ;pad
+      |#
+      (resource-id (picture-id picture))
+      
+      (card32 a)
+      (card32 b)
+      (card32 c)
+      
+      (card32 d)
+      (card32 e)
+      (card32 f)
+      
+      (card32 p)
+      (card32 q)
+      (card32 r))))
+
+(defun render-query-filters (drawable)
+  (let ((display (drawable-display drawable)))
+    (with-buffer-request-and-reply (display (extension-opcode display "RENDER") nil)
+      ((data +X-RenderQueryFilters+)
+       (drawable drawable))
+      (let* ((len (card32-get 4))
+             (n-aliases (card32-get 8))
+             (n-filters (card32-get 12))
+             (off (+ (* 8 4) (* 4 (ceiling (* 2 n-aliases) 4)))))
+        (print (list :aliases
+                     (loop for i below n-aliases collect (card16-get (+ (* 8 4) (* i 2))))))
+        (print (list :foo len n-aliases n-filters
+                     (loop for i below len
+                           collect (card8-get (+ off 0 (* 4 i)))
+                           collect (card8-get (+ off 1 (* 4 i)))
+                           collect (card8-get (+ off 2 (* 4 i)))
+                           collect (card8-get (+ off 3 (* 4 i))))))
+        (print
+         (labels ((grab-string (j)
+                    (let ((n (card8-get j)))
+                      (incf j)
+                      (values
+                       (map 'string #'code-char (loop repeat n collect (card8-get j) do (incf j)))
+                       j))))
+           (loop repeat n-filters collect
+                 (multiple-value-bind (s j) (grab-string off)
+                   (setf off j)
+                   (intern (string-upcase s) :keyword)))))
+        #+NIL
+        (loop for i below n-picture-formats
+              collect
+              (let ((off (+ (* 8 4)
+                            (* i 28)))) ;size of picture-format-info
+                (make-picture-format
+                 :display display
+                 :id         (card32-get (+ off 0))
+                 :type       (member8-get (+ off 4) :indexed :direct)
+                 :depth      (card8-get   (+ off 5))
+                 :red-byte   (byte (integer-length (card16-get (+ off 10)))
+                                   (card16-get (+ off 8)))
+                 :green-byte (byte (integer-length (card16-get (+ off 14)))
+                                   (card16-get (+ off 12)))
+                 :blue-byte  (byte (integer-length (card16-get (+ off 18)))
+                                   (card16-get (+ off 16)))
+                 :alpha-byte (byte (integer-length (card16-get (+ off 22)))
+                                   (card16-get (+ off 20)))
+                 :colormap   (let ((cmid (card32-get (+ off 24))))
+                               (unless (zerop cmid)
+                                 (lookup-colormap display cmid))))))))))
+
+(defun render-set-filter (picture filter)
+  (let ((display (picture-display picture)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state picture)
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderSetPictureFilter+)
+      (resource-id (picture-id picture))
+      (card16 (length filter))
+      (pad16 0)
+      ((sequence :format card8) (map 'vector #'char-code filter)))))
+  
+
+
+#||
+(defun render-triangle (destination source x1 y1 x2 y2 x3 y3 &key (src-x 0) (src-y 0) (format nil) (op :over))
+  (render-triangles-1 destination op source ...)
+  )
+||#
+
+(defun render-trapezoids (picture op source src-x src-y mask-format coord-sequence)
+  ;; coord-sequence is  top bottom
+  ;;                    left-x1 left-y1 left-x2 left-y2
+  ;;                    right-x1 right-y1 right-x2 right-y2 ...
+  ;;
+  (let ((display (picture-display picture)))
+    (synchronise-picture-state picture)
+    (synchronise-picture-state source)
+    (labels ((funk (x) (ash x 16)))
+      (with-buffer-request (display (extension-opcode display "RENDER"))
+        (data +X-RenderTrapezoids+)
+        (render-op op)
+        (pad8 0)
+        (pad16 0)
+        (resource-id (picture-id source))
+        (resource-id (picture-id picture))
+        ((or (member :none) picture-format) mask-format)
+        (int16 src-x)
+        (int16 src-y)
+        ((sequence :format int32 :transform #'funk) coord-sequence)))))
+
+(defun render-composite (op
+                         source mask dest
+                         src-x src-y mask-x mask-y dst-x dst-y
+                         width height)
+  (let ((display (picture-display source)))
+    (synchronise-picture-state source)
+    (when mask (synchronise-picture-state mask))
+    (synchronise-picture-state dest)
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderComposite+)
+      (render-op op)
+      (pad8 0)
+      (pad16 0)
+      (resource-id (picture-id source))
+      (resource-id (if mask (picture-id mask) 0))
+      (resource-id (picture-id dest))
+      (int16 src-x)
+      (int16 src-y)
+      (int16 mask-x)
+      (int16 mask-y)
+      (int16 dst-x)
+      (int16 dst-y)
+      (card16 width)
+      (card16 height))))
+
+(defun render-create-glyph-set (format &key glyph-set)
+  (let ((display (picture-format-display format)))
+    (let* ((glyph-set (or glyph-set (make-glyph-set :display display)))
+           (gsid (setf (glyph-set-id glyph-set)
+                       (allocate-resource-id display glyph-set 'glyph-set))))
+      (declare (ignore gsid))
+      (setf (glyph-set-format glyph-set) format)
+      (with-buffer-request (display (extension-opcode display "RENDER"))
+        (data +X-RenderCreateGlyphSet+)
+        (glyph-set glyph-set)
+        (picture-format format))
+      glyph-set)))
+
+(defun render-reference-glyph-set (existing-glyph-set &key glyph-set)
+  (let ((display (glyph-set-display existing-glyph-set)))
+    (let* ((glyph-set (or glyph-set (make-glyph-set :display display)))
+           (gsid (setf (glyph-set-id glyph-set)
+                       (allocate-resource-id display glyph-set 'glyph-set))))
+      (declare (ignore gsid))
+      (setf (glyph-set-format glyph-set)
+            (glyph-set-format existing-glyph-set))
+      (with-buffer-request (display (extension-opcode display "RENDER"))
+        (data +X-RenderReferenceGlyphSet+)
+        (glyph-set glyph-set)
+        (glyph-set existing-glyph-set))
+      glyph-set)))
+
+(defun render-composite-glyphs-8 (dest glyph-set source dest-x dest-y sequence
+                                  &key (op :over)
+                                       (alu op) ;for the fun of it
+                                       (src-x 0)
+                                       (src-y 0)
+                                       (mask-format :none)
+                                       (start 0)
+                                       (end (length sequence)))
+  (let ((display (picture-display dest)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state dest)
+    (synchronise-picture-state source)
+    (when (stringp sequence)
+      ;; lazy me, but then you should not confuse glyphs with
+      ;; characters anyway.
+      (setf sequence (map 'vector #'char-code sequence)))
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderCompositeGlyphs8+)
+      (render-op alu)
+      (pad8 0)
+      (pad16 0)
+      (picture source)
+      (picture dest)
+      ((or (member :none) picture-format) mask-format)
+      (glyph-set glyph-set)
+      (int16 src-x) (int16 src-y)
+      (card8 (- end start)) ;length of glyph elt
+      (pad8 0)
+      (pad16 0)
+      (int16 dest-x) (int16 dest-y)             ;dx, dy
+      ((sequence :format card8) sequence))))
+
+(defmacro %render-composite-glyphs
+    (opcode type transform display dest glyph-set source dest-x dest-y sequence
+     alu src-x src-y mask-format start end)
+  (let ((size (ecase type (card8 1) (card16 2) (card32 4)))
+	;; FIXME: the last chunk for CARD8 can be 254.
+	(chunksize (ecase type (card8 252) (card16 254) (card32 254))))
+    `(multiple-value-bind (nchunks leftover)
+         (floor (- end start) ,chunksize)
+       (let* ((payloadsize (+ (* nchunks (+ 8 (* ,chunksize ,size)))
+			      (if (> leftover 0)
+				  (+ 8 (* 4 (ceiling (* leftover ,size) 4)))
+				  0)))
+	      (request-length (+ 7 (/ payloadsize 4))))
+	 (declare (integer request-length))
+	 (with-buffer-request (,display (extension-opcode ,display "RENDER") :length (* 4 request-length))
+	   (data ,opcode)
+	   (length request-length)
+	   (render-op ,alu)
+           (pad8 0)
+	   (pad16 0)
+	   (picture ,source)
+	   (picture ,dest)
+	   ((or (member :none) picture-format) ,mask-format)
+	   (glyph-set ,glyph-set)
+	   (int16 ,src-x) (int16 ,src-y)
+	   (progn
+	     (let ((boffset (+ buffer-boffset 28))
+		   (start ,start)
+		   (end ,end)
+		   (dest-x ,dest-x)
+		   (dest-y ,dest-y))
+	       (dotimes (i nchunks)
+		 (set-buffer-offset boffset)
+		 (put-items (0)
+		   (card8 ,chunksize)
+		   (card8 0)
+		   (card16 0)
+		   (int16 dest-x)
+		   (int16 dest-y)
+		   ((sequence :start start :end (+ start ,chunksize) :format ,type :transform ,transform :appending t) ,sequence))
+		 (setq dest-x 0 dest-y 0)
+		 (incf boffset (+ 8 (* ,chunksize ,size)))
+		 (incf start ,chunksize))
+	       (when (> leftover 0)
+		 (set-buffer-offset boffset)
+		 (put-items (0)
+		   (card8 leftover)
+		   (card8 0)
+		   (card16 0)
+		   (int16 dest-x)
+		   (int16 dest-y)
+		   ((sequence :start start :end end :format ,type :transform ,transform :appending t) ,sequence))
+		 ;; padding?
+		 (incf boffset (+ 8 (* 4 (ceiling (* leftover ,size) 4)))))
+	       (setf (buffer-boffset ,display) boffset))))))))
+
+(defun render-composite-glyphs (dest glyph-set source dest-x dest-y sequence
+                                &key (op :over)
+                                     (alu op)   ;for the fun of it
+                                     (src-x 0)
+                                     (src-y 0)
+                                     (mask-format :none)
+                                     (start 0)
+                                     (end (length sequence)))
+  ;; xxx do we want to go with some translate function as draw-glyphs?
+  (declare (type array-index start end))
+  (let ((display (picture-display dest)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state dest)
+    (synchronise-picture-state source)
+    ;; hmm find out the element size
+    (typecase sequence
+      ((array (unsigned-byte 8) (*))
+       (%render-composite-glyphs +X-RenderCompositeGlyphs8+ card8 nil
+                                 display dest glyph-set source dest-x dest-y sequence alu src-x
+                                 src-y mask-format start end))
+      ((array (unsigned-byte 16) (*))
+       (%render-composite-glyphs +X-RenderCompositeGlyphs16+ card16 nil
+                                 display dest glyph-set source dest-x dest-y sequence alu src-x
+                                 src-y mask-format start end))
+      ((array (unsigned-byte 32) (*))
+       (%render-composite-glyphs +X-RenderCompositeGlyphs32+ card32 nil
+                                 display dest glyph-set source dest-x dest-y sequence alu src-x
+                                 src-y mask-format start end))
+      (string
+       (%render-composite-glyphs #.(cond ((<= char-code-limit (expt 2 8))  '+X-RenderCompositeGlyphs8+)
+                                         ((<= char-code-limit (expt 2 16)) '+X-RenderCompositeGlyphs16+)
+                                         ((<= char-code-limit (expt 2 32)) '+X-RenderCompositeGlyphs32+)
+                                         (t
+                                          (error "Wow!")))
+                                 #.(cond ((<= char-code-limit (expt 2 8))  'card8)
+                                         ((<= char-code-limit (expt 2 16)) 'card16)
+                                         ((<= char-code-limit (expt 2 32)) 'card32)
+                                         (t
+                                          (error "Wow!")))
+                                 #'char-code
+                                 display dest glyph-set source dest-x dest-y sequence alu src-x
+                                 src-y mask-format start end))
+      (t
+       ;; should we bother testing the array element type?
+       (%render-composite-glyphs +X-RenderCompositeGlyphs32+ card32
+                                 #'(lambda (elt)
+                                     (if (characterp elt)
+                                         (char-code elt)
+                                         elt))
+                                 display dest glyph-set source dest-x dest-y sequence alu src-x
+                                 src-y mask-format start end))) ))
+
+;; --- idea: Allow data to be an image to avoid unecessary consing? - noss
+(defun render-add-glyph (glyph-set id &key x-origin y-origin x-advance y-advance data)
+  (let ((display (glyph-set-display glyph-set)))
+    (ensure-render-initialized display)
+    (let* ((w (array-dimension data 1))
+           (h (array-dimension data 0))
+           (bitmap-format (display-bitmap-format display))
+           (unit (bitmap-format-unit bitmap-format))
+           (byte-lsb-first-p (display-image-lsb-first-p display))
+           (bit-lsb-first-p  (bitmap-format-lsb-first-p bitmap-format)))
+      (let* ((byte-per-line (* 4 (ceiling 
+				  (* w (picture-format-depth (glyph-set-format glyph-set)))
+				  32)))
+             (request-length (+ 28
+				(* h byte-per-line))))
+        (with-buffer-request (display (extension-opcode display "RENDER"))
+          (data +X-RenderAddGlyphs+)
+          (length (ceiling request-length 4))
+          (glyph-set glyph-set)
+          (card32 1) ;number glyphs
+          (card32 id) ;id
+          (card16 w)
+          (card16 h)
+          (int16 x-origin)
+          (int16 y-origin)
+          (int16 x-advance)
+          (int16 y-advance)
+          (progn
+            (setf (buffer-boffset display) (advance-buffer-offset 28))
+            (let ((im (create-image :width w :height h :depth 8 :data data)))
+              (write-image-z display im 0 0 w h
+                             byte-per-line ;padded bytes per line
+                             unit byte-lsb-first-p bit-lsb-first-p)) ))) )))
+
+(defun render-add-glyph-from-picture (glyph-set picture
+                                      &key x-origin y-origin x-advance y-advance
+                                           x y width height)
+  ;; untested, the duplication of x-origin seems bogus.
+  ;; Still untested, but these modifications seem to be more likely, (x,y) would be the offset into the picture.
+  ;; and orgin advance would be properties of the defined glyph.
+  (let ((display (glyph-set-display glyph-set)))
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderAddGlyphsFromPicture+)
+      (glyph-set glyph-set)
+      (picture picture)
+      (card16 width)
+      (card16 height)
+      (card16 x-origin)
+      (card16 y-origin)
+      (card16 x-advance)
+      (card16 y-advance)
+      (card16 x)
+      (card16 y))))
+
+;; untested
+(defun render-free-glyphs (glyph-set glyphs)
+  "This request removes glyphs from glyph-set. Each glyph must exist in glyph-set (else a Match error results)."
+  (let ((display (glyph-set-display glyph-set)))
+    (with-buffer-request (display (extension-opcode display "RENDER"))
+      (data +X-RenderFreeGlyphs+)
+      (glyph-set glyph-set)
+      ((sequence :format card32) glyphs))))
+
+
+#||
+;;; --------------------------------------------------------------------------------
+
+;; testing code:
+
+(defun x (op)
+  (let ((dpy (open-display "")))
+    (render-query-version dpy)
+    (unwind-protect
+         (let* ((win (screen-root (first (display-roots dpy))))
+                (display dpy)
+                (pf  (find-window-picture-format win))
+                (pm   (xlib:create-pixmap
+                       :depth (xlib:drawable-depth win)
+                       :drawable win :width 1 :height 1))
+                (pm.p  (render-create-picture pm
+                                              :format pf
+                                              :repeat :on))
+                (win.p (render-create-picture win :format pf))
+                (gs  (render-create-glyph-set (first
+                                               (find-matching-picture-formats
+                                                dpy
+                                                :alpha 8
+                                                :red-max 0
+                                                :green-max 0
+                                                :blue-max 0)))))
+           (xlib:clear-area win)
+           (render-fill-rectangle pm.p :src (list #xFFFF 0 0 0) 0 0 100 100)
+           (render-add-glyph gs 18
+                             :data (make-array (list 3 3)
+                                               :initial-contents '((255 000 000)
+                                                                   (000 255 000)
+                                                                   (000 000 255))
+                                               :element-type '(unsigned-byte 8))
+                             :x-advance 4
+                             :y-advance 0
+                             :x-origin 0
+                             :y-origin 0)
+           (let ((w 50)
+                 (h 50))
+             (let ((data (make-array (list h w) :element-type '(unsigned-byte 8) :initial-element 0)))
+               (dotimes (i w)
+                 (dotimes (j h)
+                   (setf (aref data i j) (* 3 i))))
+               (render-add-glyph gs 17
+                                 :data data
+                                 :x-advance (+ w 2)
+                                 :y-advance 0
+                                 :x-origin 0
+                                 :y-origin 0)))
+
+           (render-composite-glyphs-8 win.p gs pm.p
+                                      200 330
+                                      (vector 17 18 18 17 17 17 17 17 17 17)
+                                      :alu op
+                                      )
+                                      ;;
+           (display-finish-output dpy)
+           (close-display dpy)))))
+
+(defun z (op)
+  (let ((dpy (open-display "")))
+    (unwind-protect
+         (let* ((win (screen-root (first (display-roots dpy))))
+                (pic (render-create-picture win))
+                (fmt (first (find-matching-picture-formats
+                             dpy
+                             :red-min 8
+                             :green-min 8
+                             :blue-min 8
+                             :alpha-min 8)))
+                (px  (xlib:create-pixmap :width 256 :height 256 :depth (picture-format-depth fmt)
+                      :drawable win))
+                (px.pic (render-create-picture px :format fmt))
+                (px.gc (xlib:create-gcontext :drawable px)))
+           (xlib:clear-area win)
+           ;;
+           (render-fill-rectangle px.pic :src
+                                  (list #x8000 #x0000 #x8000 #xFFFF)
+                                  0 0 256 256)
+
+           (render-composite :src pic pic px.pic
+                             350 350 350 350 0 0 256 256)
+           ;;
+           (render-fill-rectangle px.pic :over
+                                  (list #x8000 #x8000 #x8000 #x8000)
+                                  0 0 100 100)
+           (render-composite :src
+                             px.pic px.pic pic
+                             0 0 0 0 350 350
+                             256 256)
+           (render-fill-rectangle pic op (list #x0 #x0 #x0 #x8000) 200 200 800 800)
+           (display-finish-output dpy))
+      (close-display dpy))))
+
+;;; ----------------------------------------------------------------------------------------------------
+
+(defun y (op)
+  (let ((dpy (open-display "")))
+    (render-query-version dpy)
+    (unwind-protect
+         (let* ((win (screen-root (first (display-roots dpy))))
+                (pic
+                  (render-create-picture win))
+                (px  (xlib:create-pixmap :drawable win
+                      :width 256
+                      :height 256
+                      :depth 32))
+                (px.gc (xlib:create-gcontext :drawable px)))
+           (dotimes (x 256)
+             (dotimes (y 256)
+               (setf (xlib:gcontext-foreground px.gc)
+                     (dpb x (byte 8 24)
+                          (dpb y (byte 8 16)
+                               (dpb y (byte 8 8)
+                                    y))))
+               (xlib:draw-point px px.gc x y)
+               ))
+           (xlib:clear-area win)
+           (let ((q (render-create-picture px
+                                           :format
+                                           (first (find-matching-picture-formats
+                                                   dpy
+                                                   :depth 32
+                                                   :alpha 8 :red 8 :green 8 :blue 8))
+                                           :component-alpha :on
+                                           :repeat :off)))
+             (render-composite op
+                               q
+                               q 
+                               pic
+                               0 0
+                               0 0
+                               100 100
+                               400 400))
+           (let ()
+             ;;(render-fill-rectangle pic op (list 255 255 255 255) 100 100 200 200)
+             (display-finish-output dpy)))
+      (close-display dpy))))
+
+(defun zz ()
+  (let* ((dpy (xlib:open-display ""))
+        (win (screen-root (first (display-roots dpy))))
+        (pic (render-create-picture win)))
+    (xlib:clear-area win)
+    (setf (picture-clip-mask pic) (list 100 100 200 2000))
+    (render-fill-rectangle pic :over (list #xFFFF 0 0 #x400) 0 0 2000 2000)
+    (display-finish-output dpy)
+    (close-display dpy)))
+||#
+
+
+;;;; Cursors
+
+(defun render-create-cursor (picture &optional (x 0) (y 0))
+  (let ((display (picture-display picture)))
+    (ensure-render-initialized display)
+    (synchronise-picture-state picture)
+    (let* ((cursor (make-cursor :display display))
+           (cid (allocate-resource-id display cursor 'cursor)))
+      (setf (cursor-id cursor) cid)
+      (with-buffer-request (display (extension-opcode display "RENDER"))
+        (data +X-RenderCreateCursor+)
+        (resource-id cid)
+        (resource-id (picture-id picture))
+        (card16 x)
+        (card16 y))
+      cursor)))
+
+(defun render-create-anim-cursor (cursors delays)
+  "Create animated cursor. cursors length must be the same as delays length."
+  (let ((display (cursor-display (first cursors))))
+    (ensure-render-initialized display)
+    (let* ((cursor (make-cursor :display display))
+           (cid (allocate-resource-id display cursor 'cursor))
+           (cursors-length (length cursors))
+           (cursors-delays (make-list (* 2 (length cursors)))))
+      (setf (xlib:cursor-id cursor) cid)
+      (dotimes (i cursors-length)
+        (setf (elt cursors-delays (* 2 i)) (cursor-id (elt cursors i))
+              (elt cursors-delays (1+ (* 2 i))) (elt delays i)))
+      (xlib::with-buffer-request (display (extension-opcode display "RENDER"))
+        (data +X-RenderCreateAnimCursor+)
+        (resource-id cid)
+        ((sequence :format card32) cursors-delays))
+      cursor)))

--- a/extensions/xtest.lisp
+++ b/extensions/xtest.lisp
@@ -1,0 +1,154 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; -*-
+;;;
+;;; Implementation of the XTest extension as described by
+;;; http://www.x.org/docs/Xext/xtest.pdf
+;;;
+;;; Written by Lionel Flandrin <lionel.flandrin@gmail.com> in july
+;;; 2008 and placed in the public domain.
+;;;
+;;; TODO:
+;;; * Implement XTestSetVisualIDOfVisual and XTestDiscard
+;;; * Add the missing (declare (type ...
+
+(defpackage :xtest
+  (:use :common-lisp :xlib)
+  (:import-from :xlib
+                #:data
+                #:card8
+                #:card8-get
+                #:card16
+                #:card16-get
+                #:card32
+                #:card32-get
+                #:extension-opcode
+                #:define-extension
+                #:gcontext
+                #:resource-id
+                #:window-id
+                #:cursor
+                #:make-cursor
+                #:with-buffer-request-and-reply
+                #:with-buffer-request
+                #:display)
+  (:export
+   ;; Constants
+   #:+major-version+
+   #:+minor-version+
+
+   ;; Functions
+   #:set-gc-context-of-gc
+   #:get-version
+   #:compare-cursor
+   #:fake-motion-event
+   #:fake-button-event
+   #:fake-key-event
+   #:grab-control))
+
+(in-package :xtest)
+
+(define-extension "XTEST")
+
+(defmacro opcode (display)
+  `(extension-opcode ,display "XTEST"))
+
+;;; The version we implement
+(defconstant +major-version+ 2)
+(defconstant +minor-version+ 2)
+
+(defconstant +none+           0)
+(defconstant +current-cursor+ 1)
+
+;;; XTest opcodes
+(defconstant +get-version+    0)
+(defconstant +compare-cursor+ 1)
+(defconstant +fake-input+     2)
+(defconstant +grab-control+   3)
+
+;;; Fake events
+(defconstant +fake-key-press+      2)
+(defconstant +fake-key-release+    3)
+(defconstant +fake-button-press+   4)
+(defconstant +fake-button-release+ 5)
+(defconstant +fake-motion-notify+  6)
+
+;;; Client operations
+(defun set-gc-context-of-gc (gcontext gcontext-id)
+  (declare (type gcontext gcontext)
+           (type resource-id gcontext-id))
+    (setf (gcontext-id gcontext) gcontext-id))
+
+;;; Server requests
+(defun get-version (display &optional (major +major-version+) (minor +minor-version+))
+  "Returns the major and minor version of the server's XTest implementation"
+  (declare (type display display))
+  (with-buffer-request-and-reply (display (opcode display) nil)
+      ((data +get-version+)
+       (card8 major)
+       (card16 minor))
+    (values (card8-get 1)
+            (card16-get 8))))
+
+(defun compare-cursor (display window &optional (cursor-id +current-cursor+))
+  (declare (type display display)
+           (type resource-id cursor-id)
+           (type window window))
+  (with-buffer-request-and-reply (display (opcode display) nil)
+      ((data +compare-cursor+)
+       (resource-id (window-id window))
+       (resource-id cursor-id))
+    (values (card8-get 1))))
+
+(defun fake-motion-event (display x y &key (delay 0) relative (root-window-id 0))
+  "Move the mouse pointer at coordinates (x, y). If :relative is t,
+the movement is relative to the pointer's current position"
+  (declare (type display display))
+  (with-buffer-request (display (opcode display))
+    (data +fake-input+)
+    (card8 +fake-motion-notify+)
+    (card8  (if relative 1 0))
+    (pad16 0)
+    (card32 delay)
+    (card32 root-window-id)
+    (pad32 0 0)
+    (card16 x)
+    (card16 y)
+    (pad32 0 0)))
+
+(defun fake-button-event (display button pressed &key (delay 0))
+  "Send a fake button event (button pressed or released) to the
+server. Most of the time, button 1 is the left one, 2 the middle and 3
+the right one but it's not always the case."
+  (declare (type display display))
+  (with-buffer-request (display (opcode display))
+    (data +fake-input+)
+    (card8 (if pressed +fake-button-press+ +fake-button-release+))
+    (card8 button)
+    (pad16 0)
+    (card32 delay)
+    (pad32 0 0 0 0 0 0)))
+
+(defun fake-key-event (display keycode pressed &key (delay 0))
+  "Send a fake key event (key pressed or released) to the server based
+on its keycode."
+  (declare (type display display))
+  (with-buffer-request (display (opcode display))
+    (data +fake-input+)
+    (card8 (if pressed +fake-key-press+ +fake-key-release+))
+    (card8 keycode)
+    (pad16 0)
+    (card32 delay)
+    (pad32 0 0 0 0 0 0)))
+
+(defun grab-control (display grab?)
+  "Make the client grab the server, that is allow it to make requests
+even when another client grabs the server."
+  (declare (type display display))
+  (with-buffer-request (display (opcode display))
+    (data +grab-control+)
+    (card8 (if grab? 1 0))
+    (pad8  0)
+    (pad16 0)))
+
+;;; Local Variables:
+;;; indent-tabs-mode: nil
+;;; End:

--- a/extensions/xvidmode.lisp
+++ b/extensions/xvidmode.lisp
@@ -1,0 +1,730 @@
+;;; -*- Mode: Lisp; Syntax: Common-Lisp; Package: XLIB; -*-
+;;; ---------------------------------------------------------------------------
+;;;     Title: XFree86 video mode extension
+;;;   Created: 2003 03 28 15:28
+;;;    Author: Iban Hatchondo <hatchond@labri.fr>
+;;; ---------------------------------------------------------------------------
+;;;  (c) copyright 2003 by Iban Hatchondo
+
+;;;
+;;; Permission is granted to any individual or institution to use,
+;;; copy, modify, and distribute this software, provided that this
+;;; complete copyright and permission notice is maintained, intact, in
+;;; all copies and supporting documentation.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+;;;
+
+;;; THIS IS NOT AN X CONSORTIUM STANDARD OR AN X PROJECT TEAM SPECIFICATION
+
+;;; DESCRIPTION
+;;;
+;;; These functions provide an interface to the server extension 
+;;; XFree86-VidModeExtension which allows the video modes to be 
+;;; queried, adjusted dynamically and the mode switching to be 
+;;; controlled.
+
+;;; [ personal notes ]
+;;;
+;;; The documentation on this extension is very poor, probably,
+;;; because it is not an X standard nor an X project team spec.
+;;; Because of that, it need to be tested on some XFree 3.3.6,
+;;; and XFree 4.3.x to ensure that all request are correctly 
+;;; constructed as well as to indentify any obsolete/wrong 
+;;; functions I made.
+
+(in-package :xlib)
+
+(export '(mode-info
+	  mode-info-dotclock
+	  mode-info-hdisplay
+	  mode-info-hsyncstart
+	  mode-info-hsyncend
+	  mode-info-htotal
+	  mode-info-hskew
+	  mode-info-vdisplay
+	  mode-info-vsyncstart
+	  mode-info-vsyncend
+	  mode-info-vtotal
+	  mode-info-flags
+	  mode-info-privsize
+	  mode-info-private
+	  make-mode-info
+
+	  xfree86-vidmode-query-version
+	  xfree86-vidmode-set-client-version
+	  xfree86-vidmode-get-permissions
+	  xfree86-vidmode-mod-mode-line 
+	  xfree86-vidmode-get-mode-line 
+	  xfree86-vidmode-get-all-mode-lines
+	  xfree86-vidmode-add-mode-line
+	  xfree86-vidmode-delete-mode-line
+	  xfree86-vidmode-validate-mode-line
+	  xfree86-vidmode-get-gamma
+	  xfree86-vidmode-set-gamma
+	  xfree86-vidmode-get-gamma-ramp
+	  xfree86-vidmode-set-gamma-ramp     
+	  xfree86-vidmode-get-gamma-ramp-size
+	  xfree86-vidmode-lock-mode-switch
+	  xfree86-vidmode-switch-to-mode
+	  xfree86-vidmode-switch-mode
+	  xfree86-vidmode-select-next-mode
+	  xfree86-vidmode-select-prev-mode
+	  xfree86-vidmode-get-monitor
+	  xfree86-vidmode-get-viewport
+	  xfree86-vidmode-set-viewport
+	  xfree86-vidmode-get-dotclocks)
+	:xlib)
+
+;; current version numbers
+;;
+;; major 0 == uses parameter-to-wire functions in XFree86 libXxf86vm.
+;; major 1 == uses parameter-to-wire functions hard-coded in xvidtune client.
+;; major 2 == uses new protocol version in XFree86 4.0.
+(defconstant +xf86vidmode-major-version+ 2)
+(defconstant +xf86vidmode-minor-version+ 2)
+
+;; requests number.
+(defconstant +query-version+        0)
+(defconstant +get-mode-line+        1)
+(defconstant +mod-mode-line+        2)
+(defconstant +switch-mode+          3)
+(defconstant +get-monitor+          4)
+(defconstant +lock-mode-switch+     5)
+(defconstant +get-all-mode-lines+   6)
+(defconstant +add-mode-line+        7)
+(defconstant +delete-mode-line+     8)
+(defconstant +validate-mode-line+   9)
+(defconstant +switch-to-mode+      10)
+(defconstant +get-viewport+        11)
+(defconstant +set-viewport+        12)
+
+;; new for version 2.x of this extension.
+(defconstant +get-dot-clocks+      13)
+(defconstant +set-client-version+  14)
+(defconstant +set-gamma+           15)
+(defconstant +get-gamma+           16)
+(defconstant +get-gamma-ramp+      17)
+(defconstant +set-gamma-ramp+      18)
+(defconstant +get-gamma-ramp-size+ 19)
+(defconstant +get-permisions+      20)
+
+(define-extension "XFree86-VidModeExtension"
+  :events (:xfree86-vidmode-notify) 
+  :errors (xf86-vidmode-bad-clock 
+	   xf86-vidmode-bad-htimings 
+	   xf86-vidmode-bad-vtimings
+	   xf86-vidmode-mode-unsuitable
+	   xf86-vidmode-extension-disabled
+	   xf86-vidmode-client-not-local
+	   xf86-vidmode-zoom-locked))
+
+(define-condition xf86-vidmode-bad-clock (request-error) ())
+(define-condition xf86-vidmode-bad-htimings (request-error) ())
+(define-condition xf86-vidmode-bad-vtimings (request-error) ())
+(define-condition xf86-vidmode-mode-unsuitable (request-error) ())
+(define-condition xf86-vidmode-extension-disabled (request-error) ())
+(define-condition xf86-vidmode-client-not-local (request-error) ())
+(define-condition xf86-vidmode-zoom-locked (request-error) ())
+
+(define-error xf86-vidmode-bad-clock decode-core-error)
+(define-error xf86-vidmode-bad-htimings decode-core-error)
+(define-error xf86-vidmode-bad-vtimings decode-core-error)
+(define-error xf86-vidmode-mode-unsuitable decode-core-error)
+(define-error xf86-vidmode-extension-disabled decode-core-error)
+(define-error xf86-vidmode-client-not-local decode-core-error)
+(define-error xf86-vidmode-zoom-locked  decode-core-error)
+
+(declare-event :XFree86-VidMode-notify
+  (card16 sequence)
+  (window (window event-window)) ; the root window of event screen
+  (int16 state)                  ; what happend
+  (int16 kind)                   ; what happend
+  (boolean forced-p)             ; extents of a new region
+  ((or null card32) time))       ; event timestamp
+
+(defstruct mode-info
+  (dotclock 0 :type card32)
+  (hdisplay   0 :type card16)
+  (hsyncstart 0 :type card16)
+  (hsyncend   0 :type card16)
+  (htotal     0 :type card16)
+  (hskew      0 :type card32)
+  (vdisplay   0 :type card16)
+  (vsyncstart 0 :type card16)
+  (vsyncend   0 :type card16)
+  (vtotal     0 :type card16)
+  (flags      0 :type card32)
+  (privsize   0 :type card32)
+  (private    nil :type sequence))
+
+(defmacro vidmode-opcode (display)
+  `(extension-opcode ,display "XFree86-VidModeExtension"))
+
+(declaim (inline screen-position))
+(defun screen-position (screen display)
+  (declare (type display display)
+	   (type screen screen))
+  (declare (clx-values position))
+  (let ((position (position screen (xlib:display-roots display))))
+    (if (not (numberp position))
+	(error "screen ~A not found in display ~A" screen display)
+	position)))
+
+(declaim (inline __card32->card16__))
+(defun __card32->card16__ (i)
+  (declare (type card32 i))
+  #+clx-little-endian
+  (progn (values (ldb (byte 16 0) i) (ldb (byte 32 16) i)))
+  #-clx-little-endian
+  (progn (values (ldb (byte 32 16) i) (ldb (byte 16 0) i))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;                                                                       ;;;;
+;;;;              public XFree86-VidMode Extension routines                ;;;;
+;;;;                                                                       ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun xfree86-vidmode-query-version (display)
+  "Determine the version of the extension built into the server.
+return two values major-version and minor-version in that order."
+  (declare (type display display))
+  (with-buffer-request-and-reply
+      (display (vidmode-opcode display) nil :sizes 16)
+    ((data +query-version+))
+   (let ((major (card16-get 8))
+	 (minor (card16-get 10)))
+     (declare (type card16 major minor))
+     (when (>= major 2)
+       (XFree86-VidMode-set-client-version display))
+     (values major minor))))
+
+(defun xfree86-vidmode-set-client-version (display)
+  (declare (type display display))
+  (with-buffer-request (display (vidmode-opcode display))
+    (data +set-client-version+)
+    (card16 +xf86vidmode-major-version+)
+    (card16 +xf86vidmode-minor-version+)))
+
+(defun xfree86-vidmode-get-permissions (dpy screen)
+  (declare (type display dpy)
+	   (type screen screen))
+  (with-buffer-request-and-reply
+      (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+    ((data +get-permisions+)
+     (card16 (screen-position screen dpy))
+     (card16 0))
+   (values 
+    (card32-get 8))))
+
+(defun xfree86-vidmode-mod-mode-line (display screen mode-line)
+  "Change the settings of the current video mode provided the 
+requested settings are valid (e.g. they don't exceed the 
+capabilities of the monitor)."
+  (declare (type display display)
+	   (type screen screen))
+  (let* ((major (xfree86-vidmode-query-version display))
+	 (v (mode-info->v-card16 mode-line major)))
+    (declare (type card16 major)
+	     (type simple-vector v))
+    (with-buffer-request (display (vidmode-opcode display))
+      (data +mod-mode-line+)
+      (card32 (screen-position screen display))
+      ((sequence :format card16 :start 2) v))))
+
+(defun xfree86-vidmode-get-mode-line (display screen)
+  "Query the settings for the currently selected video mode.
+return a mode-info structure fields with the server answer.
+If there are any server  private  values (currently  only 
+applicable  to  the S3 server) the function will store it 
+into the returned structure."
+  (declare (clx-values mode-info)
+	   (type display display)
+	   (type screen screen))
+  (let ((major (xfree86-vidmode-query-version display))
+	(offset 8))
+    (declare (type fixnum offset)
+	     (type card16 major))    
+    (with-buffer-request-and-reply
+        (display (vidmode-opcode display) nil :sizes (8 16 32))
+      ((data +get-mode-line+)
+       (card16 (screen-position screen display))
+       (card16 0))
+     (let ((mode-info 
+	    (make-mode-info
+	        :dotclock (card32-get offset)
+		:hdisplay (card16-get (incf offset 4))
+		:hsyncstart (card16-get (incf offset 2))
+		:hsyncend (card16-get (incf offset 2))
+		:htotal (card16-get (incf offset 2))
+		:hskew (if (< major 2) 0 (card16-get (incf offset 2)))
+		:vdisplay (card16-get (incf offset 2))
+		:vsyncstart (card16-get (incf offset 2))
+		:vsyncend (card16-get (incf offset 2))
+		:vtotal (card16-get (incf offset 2))
+		:flags (card32-get (incf offset (if (< major 2) 2 4)))))
+	   (size (card32-get (incf offset (if (< major 2) 4 16)))))
+       (declare (type card32 size))
+       (incf offset 4)
+       (setf (mode-info-privsize mode-info) size
+	     (mode-info-private mode-info)
+	     (sequence-get :format card32 :index offset
+			   :length size :result-type 'list))
+       mode-info))))
+
+(defun xfree86-vidmode-get-all-mode-lines (dpy screen)
+  "Returns a list containing all video modes (as mode-info structure). 
+The first element of the list corresponds to the current video mode."
+  (declare (type display dpy)
+	   (type screen screen))
+  (multiple-value-bind (major minor) (xfree86-vidmode-query-version dpy)
+    (declare (type card16 major minor))
+    (with-buffer-request-and-reply 
+        (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+      ((data +get-all-mode-lines+)
+       (card16 (screen-position screen dpy)))
+     (values 
+      ;; Note: There was a bug in the protocol implementation in versions
+      ;; 0.x with x < 8 (the .private field wasn't being passed over the wire).
+      ;; Check the server's version, and accept the old format if appropriate.
+      (loop with bug-p = (and (= major 0) (< minor 8))
+	    with offset of-type fixnum = 32
+            for i of-type card32 from 0 below (or (card32-get 8) 0)
+	    collect
+	     (let ((mode-info
+		    (make-mode-info
+		       :dotclock (card32-get offset)
+		       :hdisplay (card16-get (incf offset 4))
+		       :hsyncstart (card16-get (incf offset 2))
+		       :hsyncend (card16-get (incf offset 2))
+		       :htotal (card16-get (incf offset 2))
+		       :hskew (if (< major 2) 0 (card32-get (incf offset 2)))
+		       :vdisplay (card16-get (incf offset 4))
+		       :vsyncstart (card16-get (incf offset 2))
+		       :vsyncend (card16-get (incf offset 2))
+		       :vtotal (card16-get (incf offset 2))
+		       :flags (card32-get (incf offset (if (< major 2) 2 6)))))
+		   (size (card32-get (incf offset (if (< major 2) 4 16)))))
+		(declare (type card32 size))
+		(incf offset 4)
+		(when bug-p 
+		  (setf size 0))
+		(setf (mode-info-privsize mode-info) size
+		      (mode-info-private mode-info)
+		      (sequence-get :format card32 :index offset
+				    :length size :result-type 'list))
+		(incf offset (* 4 size))
+		mode-info))))))
+
+(defun xfree86-vidmode-add-mode-line (dpy scr new &key (after (make-mode-info)))
+  (declare (type display dpy)
+	   (type screen scr))
+  (let* ((private (mode-info-private new))
+	 (privsize (mode-info-privsize new))
+	 (major (xfree86-vidmode-query-version dpy))
+	 (i (if (< major 2) 14 22))
+	 (v (make-array (- (+ (* 2 i) (* 2 privsize)) 2) :initial-element 0)))
+    (declare (type card32 privsize)
+	     (type fixnum i)
+	     (type card16 major)
+	     (type simple-vector v))
+    (mode-info->v-card16 new major :encode-private nil :data v)
+    (mode-info->v-card16 after major :encode-private nil :data v :index i)
+    (setf i (- (* 2 i) 2))
+    ;; strore private info (sequence card32) according clx bytes order.
+    (loop for card of-type card32 in private
+	  do (multiple-value-bind (w1 w2) (__card32->card16__ card)
+	       (setf (svref v (incf i)) w1
+		     (svref v (incf i)) w2)))
+    
+    (with-buffer-request (dpy (vidmode-opcode dpy))
+      (data +add-mode-line+)
+      (card32 (screen-position scr dpy))
+      ((sequence :format card16) v))))
+
+(defun xfree86-vidmode-delete-mode-line (dpy scr mode-info)
+  "Delete mode argument. The specified mode must match an existing mode. 
+To be considered a match, all of the fields of the given mode-info 
+structure must match, except the privsize and private fields. 
+If the mode to be deleted is the current mode, a mode switch to the next 
+mode will occur first. The last remaining mode can not be deleted."
+  (declare (type display dpy)
+	   (type screen scr))
+  (let* ((major (xfree86-vidmode-query-version dpy))
+	 (v (mode-info->v-card16 mode-info major)))
+    (declare (type card16 major)
+	     (type simple-vector v))
+    (with-buffer-request (dpy (vidmode-opcode dpy))
+      (data +delete-mode-line+)
+      (card32 (screen-position scr dpy))
+      ((sequence :format card16) v))))
+
+(defconstant +mode-status+
+  '#(:MODE_BAD             ; unspecified reason 
+     :MODE_ERROR           ; error condition 
+     :MODE_OK              ; Mode OK 
+     :MODE_HSYNC           ; hsync out of range 
+     :MODE_VSYNC           ; vsync out of range 
+     :MODE_H_ILLEGAL       ; mode has illegal horizontal timings 
+     :MODE_V_ILLEGAL       ; mode has illegal horizontal timings 
+     :MODE_BAD_WIDTH       ; requires an unsupported linepitch 
+     :MODE_NO_MODE         ; no mode with a maching name 
+     :MODE_NO_INTERLACE    ; interlaced mode not supported 
+     :MODE_NO_DBLESCAN     ; doublescan mode not supported 
+     :MODE_NO_VSCAN        ; multiscan mode not supported 
+     :MODE_MEM             ; insufficient video memory 
+     :MODE_VIRTUAL_X       ; mode width too large for specified virtual size 
+     :MODE_VIRTUAL_Y       ; mode height too large for specified virtual size 
+     :MODE_MEM_VIRT        ; insufficient video memory given virtual size 
+     :MODE_NOCLOCK         ; no fixed clock available 
+     :MODE_CLOCK_HIGH      ; clock required is too high 
+     :MODE_CLOCK_LOW       ; clock required is too low 
+     :MODE_CLOCK_RANGE     ; clock/mode isn't in a ClockRange 
+     :MODE_BAD_HVALUE      ; horizontal timing was out of range 
+     :MODE_BAD_VVALUE      ; vertical timing was out of range 
+     :MODE_BAD_VSCAN       ; VScan value out of range 
+     :MODE_HSYNC_NARROW    ; horizontal sync too narrow 
+     :MODE_HSYNC_WIDE      ; horizontal sync too wide 
+     :MODE_HBLANK_NARROW   ; horizontal blanking too narrow 
+     :MODE_HBLANK_WIDE     ; horizontal blanking too wide 
+     :MODE_VSYNC_NARROW    ; vertical sync too narrow 
+     :MODE_VSYNC_WIDE      ; vertical sync too wide 
+     :MODE_VBLANK_NARROW   ; vertical blanking too narrow 
+     :MODE_VBLANK_WIDE     ; vertical blanking too wide 
+     :MODE_PANEL           ; exceeds panel dimensions 
+     :MODE_INTERLACE_WIDTH ; width too large for interlaced mode 
+     :MODE_ONE_WIDTH       ; only one width is supported 
+     :MODE_ONE_HEIGHT      ; only one height is supported 
+     :MODE_ONE_SIZE        ; only one resolution is supported 
+     ))
+
+(defun decode-status-mode (status)
+  (declare (type int32 status))
+  (svref +mode-status+ (+ status 2)))
+
+(defun xfree86-vidmode-validate-mode-line (dpy scr mode-info)
+  "Checked the validity of a mode-info argument. If the specified mode can be 
+used by the server (i.e. meets all the constraints placed upon a mode by the 
+combination of the server, card, and monitor) the function returns :mode_ok
+otherwise it returns a keyword indicating  the  reason why the mode is 
+invalid."
+  (declare (type display dpy)
+	   (type screen scr))
+  (let* ((major (xfree86-vidmode-query-version dpy))
+	 (v (mode-info->v-card16 mode-info major)))
+    (declare (type card16 major)
+	     (type simple-vector v))
+    (with-buffer-request-and-reply
+        (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+      ((data +validate-mode-line+)
+       (card32 (screen-position scr dpy))
+       ((sequence :format card16) v))
+     (let ((status (integer-get 8)))
+       (declare (type int32 status))
+       (when status (decode-status-mode status))))))
+
+(defun xfree86-vidmode-get-gamma (display screen)
+  (declare (type display display)
+	   (type screen screen))
+  (with-buffer-request-and-reply 
+      (display (vidmode-opcode display) nil :sizes (8 16 32))
+    ((data +get-gamma+)
+     (card16 (screen-position screen display))
+     (card16 0)
+     (card32 0) (card32 0)
+     (card32 0) (card32 0)
+     (card32 0) (card32 0))
+   (values 
+    (/ (the card32 (or (card32-get 8) 0)) 10000.0)
+    (/ (the card32 (or (card32-get 12) 0)) 10000.0)
+    (/ (the card32 (or (card32-get 16) 0)) 10000.0))))
+
+(defun xfree86-vidmode-set-gamma (dpy scr &key (red 1.0) (green 1.0) (blue 1.0))
+  (declare (type display dpy)
+	   (type screen scr)
+	   (type (single-float 0.100f0 10.000f0) red green blue))
+  (with-buffer-request (dpy (vidmode-opcode dpy))
+    (data +set-gamma+)
+    (card16 (screen-position scr dpy))
+    (card16 0)
+    (card32 (truncate (* red 10000)))
+    (card32 (truncate (* green 10000)))
+    (card32 (truncate (* blue 10000)))
+    (card32 0) 
+    (card32 0)
+    (card32 0)))
+
+(defun xfree86-vidmode-get-gamma-ramp (dpy scr size)
+  (declare (type display dpy)
+	   (type screen scr)
+	   (type card16 size))
+  (with-buffer-request-and-reply (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+    ((data +get-gamma-ramp+)
+     (card16 (screen-position scr dpy))
+     (card16 size))
+   (let ((rep-size (* (the card16 (or (card16-get 8) 0)) 2)))
+     (declare (type fixnum rep-size))
+     (unless (zerop rep-size)
+       (let* ((off1 (+ 32 rep-size (* 2 (mod rep-size 2))))
+	      (off2 (+ off1 rep-size (* 2 (mod rep-size 2)))))
+	 (declare (type fixnum off1 off2))
+	 (values
+	  (sequence-get :format card16 :length (card16-get 8)
+			:index 32 :result-type 'list)
+	  (sequence-get :format card16 :length (card16-get 8)
+			:index off1 :result-type 'list)
+	  (sequence-get :format card16 :length (card16-get 8)
+			:index off2 :result-type 'list)))))))
+
+(defun xfree86-vidmode-set-gamma-ramp (dpy scr size &key red green blue)
+  (declare (type (or null simple-vector) red green blue)
+	   (type card16 size)
+	   (type display dpy)
+	   (type screen scr))
+  (with-buffer-request (dpy (vidmode-opcode dpy))
+    (data +set-gamma-ramp+)
+    (card16 (screen-position scr dpy))
+    (card16 size)
+    ((sequence :format card16) 
+     (if (zerop (mod size 2))
+	 (concatenate 'vector red green blue)
+         (concatenate 'vector red '#(0) green '#(0) blue '#(0))))))
+
+(defun xfree86-vidmode-get-gamma-ramp-size (dpy screen)
+  (declare (type display dpy)
+	   (type screen screen))
+  (with-buffer-request-and-reply 
+      (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+    ((data +get-gamma-ramp-size+)
+     (card16 (screen-position screen dpy))
+     (card16 0))
+    (card16-get 8)))
+
+(defun xfree86-vidmode-lock-mode-switch (display screen lock-p)
+  "Allow or disallow mode switching whether the request to switch
+modes comes from a call to the mode switching functions or from one 
+of the mode switch key sequences (e.g. Ctrl-Alt-+ Ctrl-Alt--)."
+  (declare (type display display)
+	   (type screen screen)
+	   (type boolean lock-p))
+  (with-buffer-request (display (vidmode-opcode display))
+    (data +lock-mode-switch+)
+    (card16 (screen-position screen display))
+    (card16 (if lock-p 1 0))))
+
+(defun xfree86-vidmode-switch-to-mode (display screen mode-info)
+  "Switch directly to the specified mode. The specified mode must match 
+an existing mode. Matching is as specified in the description of the 
+xf86-vidmode-delete-mode-line function."
+  (declare (type display display)
+	   (type screen screen))
+  (multiple-value-bind (major minor) (xfree86-vidmode-query-version display)
+    (declare (type card16 major minor))
+    ;; Note: There was a bug in the protocol implementation in versions
+    ;; 0.x with x < 8 (the .private field wasn't being passed over the wire).
+    ;; Check the server's version, and accept the old format if appropriate.
+    (let ((bug-p (and (= major 0) (< minor 8)))
+	  (privsize (mode-info-privsize mode-info)))
+      (declare (type boolean bug-p))
+      (and bug-p (setf (mode-info-privsize mode-info) 0))
+      (let ((v (mode-info->v-card16 mode-info major :encode-private bug-p)))
+	(declare (type simple-vector v))
+	(and bug-p (setf (mode-info-privsize mode-info) privsize))
+	(with-buffer-request (display (vidmode-opcode display))
+	  (data +switch-to-mode+)
+	  (card32 (screen-position screen display))
+	  ((sequence :format card16) v))))))
+
+(defun xfree86-vidmode-switch-mode (display screen zoom)
+  "Change the video mode to next (or previous) video mode, depending 
+of zoom sign. If positive, switch to next mode, else switch to prev mode."
+  (declare (type display display)
+	   (type screen screen)
+	   (type card16 zoom))
+  (with-buffer-request (display (vidmode-opcode display))
+    (data +switch-mode+)
+    (card16 (screen-position screen display))
+    (card16 zoom)))
+
+(defun xfree86-vidmode-select-next-mode (display screen)
+  "Change the video mode to next video mode"
+  (declare (type display display)
+	   (type screen screen))
+  (with-buffer-request (display (vidmode-opcode display))
+    (data +switch-mode+)
+    (card16 (screen-position screen display))
+    (card16 1)))
+
+(defun xfree86-vidmode-select-prev-mode (display screen)
+  "Change the video mode to previous video mode"
+  (declare (type display display)
+	   (type screen screen))
+  (with-buffer-request (display (vidmode-opcode display))
+    (data +switch-mode+)
+    (card16 (screen-position screen display))
+    (card16 #xFFFF)))
+
+(defun xfree86-vidmode-get-monitor (dpy screen)
+  "Information known to the server about the monitor is returned. 
+Multiple value return:
+ hsync (list of hi, low, ...)
+ vsync (list of hi, low, ...)
+ vendor name
+ model name 
+
+The hi and low values will be equal if a discreate value was given 
+in the XF86Config file."
+  (declare (type display dpy)
+	   (type screen screen))
+  (with-buffer-request-and-reply
+      (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+    ((data +get-monitor+)
+     (card16 (screen-position screen dpy))
+     (card16 0))
+   (let* ((vendor-name-length (card8-get 8))
+	  (model-name-length (card8-get 9))
+	  (pad (- 4 (mod vendor-name-length 4)))
+	  (nhsync (card8-get 10))
+	  (nvsync (card8-get 11))
+	  (vindex (+ 32 (* 4 (+ nhsync nvsync))))
+	  (mindex (+ vindex vendor-name-length pad))
+	  (hsync (sequence-get :length nhsync :index 32 :result-type 'list))
+	  (vsync (sequence-get :length nvsync :index (+ 32 (* nhsync 4))
+			       :result-type 'list)))
+     (declare (type card8 nhsync nvsync vendor-name-length model-name-length)
+	      (type fixnum pad vindex mindex))
+     (values 
+      (loop for i of-type card32 in hsync
+	    collect (/ (ldb (byte 16 0) i) 100.)
+	    collect (/ (ldb (byte 32 16) i) 100.))
+      (loop for i of-type card32 in vsync
+	    collect (/ (ldb (byte 16 0) i) 100.)
+	    collect (/ (ldb (byte 32 16) i) 100.))
+      (string-get vendor-name-length vindex)
+      (string-get model-name-length mindex)))))
+
+(defun xfree86-vidmode-get-viewport (dpy screen)
+  "Query the location of the upper left corner of the viewport into 
+the virtual screen. The upper left coordinates will be returned as 
+a multiple value."
+  (declare (type display dpy)
+	   (type screen screen))
+  (multiple-value-bind (major minor) (xfree86-vidmode-query-version dpy)
+    (declare (type card16 major minor))
+    ;; Note: There was a bug in the protocol implementation in versions
+    ;; 0.x with x < 8 (no reply was sent, so the client would hang)
+    ;; Check the server's version, and don't wait for a reply with older
+    ;; versions.
+    (when (and (= major 0) (< minor 8))
+      (format cl:*error-output* 
+	      "running an old version ~a ~a~%"
+	      major minor)
+      (return-from xfree86-vidmode-get-viewport nil))
+    (with-buffer-request-and-reply 
+	(dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+      ((data +get-viewport+)
+       (card16 (screen-position screen dpy))
+       (card16 0))
+     (values
+      (card32-get 8)
+      (card32-get 12)))))
+       
+(defun xfree86-vidmode-set-viewport (dpy screen &key (x 0) (y 0))
+  "Set upper left corner of the viewport into the virtual screen to the 
+x and y keyword parameters value (zero will be theire default value)."
+  (declare (type display dpy)
+	   (type screen screen)
+	   (type card32 x y))
+  (with-buffer-request (dpy (vidmode-opcode dpy))
+    (data +set-viewport+)
+    (card16 (screen-position screen dpy))
+    (card16 0)
+    (card32 x)
+    (card32 y)))
+
+(defun xfree86-vidmode-get-dotclocks (dpy screen)
+  "Returns as a multiple value return the server dotclock informations:
+ flags
+ maxclocks
+ clock list"
+  (declare (type display dpy)
+	   (type screen screen))
+  (with-buffer-request-and-reply 
+      (dpy (vidmode-opcode dpy) nil :sizes (8 16 32))
+    ((data +get-dot-clocks+)
+     (card16 (screen-position screen dpy))
+     (card16 0))
+   (values
+    (card32-get 8)  ; flags
+    (card32-get 16) ; max clocks
+    (sequence-get :length (card32-get 12) :format card32
+		  :index 32 :result-type 'list))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;                                                                       ;;;;
+;;;;                       private utility routines                        ;;;;
+;;;;                                                                       ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun mode-info->v-card16
+    (mode-info major &key (encode-private t) (index 0) data)
+  (declare (type integer index)
+	   (type card16 major)
+	   (type boolean encode-private)
+	   (type (or null simple-vector) data))
+  (let ((dotclock (mode-info-dotclock mode-info))
+	(hdisplay (mode-info-hdisplay mode-info))
+	(hsyncstart (mode-info-hsyncstart mode-info))
+	(hsyncend (mode-info-hsyncend mode-info))
+	(htotal (mode-info-htotal mode-info))
+	(hskew (mode-info-hskew mode-info))
+	(vdisplay (mode-info-vdisplay mode-info))
+	(vsyncstart (mode-info-vsyncstart mode-info))
+	(vsyncend (mode-info-vsyncend mode-info))
+	(vtotal (mode-info-vtotal mode-info))
+	(flags (mode-info-flags mode-info))
+	(privsize (mode-info-privsize mode-info))
+	(private (mode-info-private mode-info)))
+    (declare (type card16 hdisplay hsyncstart hsyncend htotal hskew)
+	     (type card16 vdisplay vsyncstart vsyncend vtotal)
+	     (type card32 dotclock flags privsize)
+	     (type (or null sequence) private))
+    (let* ((size (+ (if (< major 2) 14 22) (* privsize 2)))
+	   (v (or data (make-array size :initial-element 0))))      
+      (declare (type fixnum size)
+	       (type simple-vector v))
+      ;; store dotclock (card32) according clx bytes order.
+      (multiple-value-bind (w1 w2) (__card32->card16__ dotclock)
+	(setf (svref v index) w1
+	      (svref v (incf index)) w2))
+      (setf (svref v (incf index)) hdisplay
+	    (svref v (incf index)) hsyncstart
+	    (svref v (incf index)) hsyncend
+	    (svref v (incf index)) htotal)
+      (unless (< major 2)
+	(setf (svref v (incf index)) hskew))
+      (setf (svref v (incf index)) vdisplay
+	    (svref v (incf index)) vsyncstart
+	    (svref v (incf index)) vsyncend
+	    (svref v (incf index)) vtotal)
+      (unless (< major 2)
+	(incf index))
+      ;; strore flags (card32) according clx bytes order.
+      (multiple-value-bind (w1 w2) (__card32->card16__ flags)
+	(setf (svref v (incf index)) w1
+	      (svref v (incf index)) w2))
+      ;; strore privsize (card32) according clx bytes order.
+      (multiple-value-bind (w1 w2) (__card32->card16__ privsize)
+	(setf (svref v (incf index)) w1
+	      (svref v (incf index)) w2))
+      ;; reserverd byte32 1 2 3
+      (unless (< major 2) (incf index 6))
+      ;; strore private info (sequence card32) according clx bytes order.
+      (when encode-private
+	(loop for i of-type int32 in private
+	      do (multiple-value-bind (w1 w2) (__card32->card16__ i)
+		   (setf (svref v (incf index)) w1
+			 (svref v (incf index)) w2))))
+      v)))


### PR DESCRIPTION
ok, seeing as there was some interest, I did a quick fix for the compile problems.  Still haven't been able to recover my latest work off my crashed harddrives, so a few functions are commented out in RandR (rr-set-crtc-transform, rr-query-provider-property, and both set and get panning) everything else should work.  .  Double checked DBE and works fine.

I should hopefully either recover the files or just rewrite the missing functions in February.