### PR TITLE
Fix PROCESS-BLOCK implementation for CCL

### DIFF
--- a/dep-openmcl.lisp
+++ b/dep-openmcl.lisp
@@ -492,8 +492,12 @@
 ;;; value changes.
 
 (defun process-block (whostate predicate &rest predicate-args)
-  (declare (dynamic-extent predicate-args))
-  (apply #'ccl:process-wait whostate predicate predicate-args))
+  (declare (ignore whostate))
+  (declare (type function predicate))
+  (loop
+   (when (apply predicate predicate-args)
+     (return))
+   (process-allow-schedule)))
 
 ;;; PROCESS-WAKEUP: Check some other process' wait function.
 


### PR DESCRIPTION
The previous implementation depended on CCL's `**process-wait**` function which is particularly inefficient as depends on CCL's internal `*ccl::**ns-per-tick***` static variable, which, by default, is set to a very high value, which causes very poor performance, as seen in https://github.com/robert-strandh/McCLIM/issues/50 - CCL spends most of its time sleeping instead of rendering objects.

The fix suggested on `#ccl` IRC channel has a different solution that doesn't include changing this value in CCL but rather fixing CLX code, so it no longer depends on CCL's `**process-wait**` function but instead copies Steel Bank Common Lisp's behaviour on the matter, with the exception that the wrapped `**yield**` function seen in https://github.com/sharplispers/clx/blob/master/dependent.lisp#L1164 is not anyhow wrapped, even for compiler declarations as they were deemed unnecessary, and is instead replaced with CCL's exported `**process-allow-schedule**` function - the CCL equivalent of SBCL's `extern-alien "sched_yield"`.

This fix was tested on McCLIM on CCL and generates a ~100x speedup  when rendering images and TrueType fonts.

Merging this fix will allow McCLIM to have TrueType support enabled by default on CCL and will greatly speed up other rendering on CCL.