### PR TITLE
Use Travis to publish manual on gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: bash
+sudo: required
+dist: trusty
+
+notifications:
+  - email: false
+
+addons:
+  apt:
+    packages:
+      - texinfo
+
+script:
+
+after_success:
+  - bash ci-doc-gh-pages.sh

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ demo/, it's generally /not/ considered good style to switch to the
 language reference to familiarize yourself with USE-PACKAGE, or 
 better yet, the USE option to DEFPACKAGE.
 
+# Documentation
+
+An up to date version of the manual can be found at [sharplispers.github.io/clx](https://sharplispers.github.io/clx/)
+
+#Bug reports, new features, patches
+
+Please use github to track issues:
 # Contributing
 
 To contribute submit a [pull request](https://github.com/sharplispers/clx/pulls)

--- a/ci-doc-gh-pages.sh
+++ b/ci-doc-gh-pages.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ "$TRAVIS_BRANCH" != "master" ]
+then
+  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  exit 0
+fi
+
+rev=$(git rev-parse --short HEAD)
+
+mkdir -p stage/_book
+
+command -v texi2any >/dev/null 2>&1 || { echo >&2 "texi2any is required but it's not installed. Aborting."; exit 1; }
+texi2any --html manual/clx.texinfo -o stage/_book
+
+cd stage/_book
+
+git init
+git config user.name "Documentation Bot"
+git config user.email "Bender@future.com"
+
+git remote add upstream "https://$GH_TOKEN@github.com/PuercoPop/clx-manual-ci-test.git"
+git fetch upstream
+git reset upstream/gh-pages
+
+touch .
+git add -A .
+git commit -m "rebuild pages at ${rev}"
+git push -q upstream HEAD:gh-pages

--- a/ci-doc-gh-pages.sh
+++ b/ci-doc-gh-pages.sh
@@ -13,9 +13,11 @@ rev=$(git rev-parse --short HEAD)
 mkdir -p stage/_book
 
 command -v texi2any >/dev/null 2>&1 || { echo >&2 "texi2any is required but it's not installed. Aborting."; exit 1; }
-texi2any --html manual/clx.texinfo -o stage/_book
+texi2any --html manual/clx.texinfo -css-ref=style.css -o stage/_book
+cp manual/style.css stage/_book
 
 cd stage/_book
+
 
 git init
 git config user.name "Documentation Bot"

--- a/manual/style.css
+++ b/manual/style.css
@@ -1,0 +1,48 @@
+body {font-family: Georgia, serif;
+      line-height: 1.3;
+      padding-left: 5em; padding-right: 1em;
+      padding-bottom: 1em; max-width: 60em;}
+table {border-collapse: collapse}
+span.roman { font-family: century schoolbook, serif; font-weight: normal; }
+h1, h2, h3, h4, h5, h6 {font-family:  Helvetica, sans-serif}
+h4 { margin-top: 2.5em; }
+dfn {font-family: inherit; font-variant: italic; font-weight: bolder }
+kbd {font-family: monospace; text-decoration: underline}
+/*var {font-family: Helvetica, sans-serif; font-variant: slanted}*/
+var {font-variant: slanted;}
+td  {padding-right: 1em; padding-left: 1em}
+sub {font-size: smaller}
+.node {padding: 0; margin: 0}
+
+pre.lisp { font-family: monospace;
+           background-color: #F4F4F4; border: 1px solid #AAA;
+           padding-top: 0.5em; padding-bottom: 0.5em; }
+
+/* coloring */
+
+.lisp-bg { background-color: #F4F4F4 ; color: black; }
+.lisp-bg:hover { background-color: #F4F4F4 ; color: black; }
+
+.symbol { font-weight: bold; color: #770055; background-color : transparent; border: 0px; margin: 0px;}
+a.symbol:link { font-weight: bold; color : #229955; background-color : transparent; text-decoration: none; border: 0px; margin: 0px; }
+a.symbol:active { font-weight: bold; color : #229955; background-color : transparent; text-decoration: none; border: 0px; margin: 0px; }
+a.symbol:visited { font-weight: bold; color : #229955; background-color : transparent; text-decoration: none; border: 0px; margin: 0px; }
+a.symbol:hover { font-weight: bold; color : #229955; background-color : transparent; text-decoration: none; border: 0px; margin: 0px; }
+.special { font-weight: bold; color: #FF5000; background-color: inherit; }
+.keyword { font-weight: bold; color: #770000; background-color: inherit; }
+.comment { font-weight: normal; color: #007777; background-color: inherit; }
+.string  { font-weight: bold; color: #777777; background-color: inherit; }
+.character   { font-weight: bold; color: #0055AA; background-color: inherit; }
+.syntaxerror { font-weight: bold; color: #FF0000; background-color: inherit; }
+span.paren1 { font-weight: bold; color: #777777; }
+span.paren1:hover { color: #777777; background-color: #BAFFFF; }
+span.paren2 { color: #777777; }
+span.paren2:hover { color: #777777; background-color: #FFCACA; }
+span.paren3 { color: #777777; }
+span.paren3:hover { color: #777777; background-color: #FFFFBA; }
+span.paren4 { color: #777777; }
+span.paren4:hover { color: #777777; background-color: #CACAFF; }
+span.paren5 { color: #777777; }
+span.paren5:hover { color: #777777; background-color: #CAFFCA; }
+span.paren6 { color: #777777; }
+span.paren6:hover { color: #777777; background-color: #FFBAFF; }


### PR DESCRIPTION
Hi,
With this pull request, travis will export the texinfo manual to html using texi2any on every commit at master and publish using github pages. However for this PR to work _someone with administrative access_ to the repository will have to do two things:
- Ensure there is a [gh-pages branch](https://help.github.com/articles/creating-project-pages-manually/#create-a-gh-pages-branch). This branch should be an orphan
- generate a personal access token with the public_repo scope and save the secret in travis under the name `GH_TOKEN`

How to do so is describe in detail in this [guide](http://www.steveklabnik.com/automatically_update_github_pages_with_travis_example/).

To test the travis configuration I setup a [repo](https://github.com/PuercoPop/clx-manual-ci-test). You can see how it looks at: https://puercopop.github.io/clx-manual-ci-test/. (It could use some CSS love ;p)

This way the recent additions to the manual made by @robert-strandh will be automatically published 
