### PR TITLE
Deallocate resource IDs when freeing up things

### DIFF
--- a/extensions/xrender.lisp
+++ b/extensions/xrender.lisp
@@ -525,13 +525,15 @@ by every function, which attempts to generate RENDER requests."
   (let ((display (picture-display picture)))
     (with-buffer-request (display (extension-opcode display "RENDER"))
       (data +X-RenderFreePicture+)
-      (picture  picture))))
+      (picture  picture))
+    (deallocate-resource-id display (picture-id picture) 'picture)))
 
 (defun render-free-glyph-set (glyph-set)
   (let ((display (glyph-set-display glyph-set)))
     (with-buffer-request (display (extension-opcode display "RENDER"))
       (data +X-RenderFreeGlyphSet+)
-      (glyph-set  glyph-set))))
+      (glyph-set  glyph-set))
+    (deallocate-resource-id display (glyph-set-id glyph-set) 'glyph-set)))
 
 (defun render-query-version (display)
   (with-buffer-request-and-reply (display (extension-opcode display "RENDER") nil)

--- a/fonts.lisp
+++ b/fonts.lisp
@@ -252,7 +252,8 @@
       (setf (display-font-cache display) (delete font (display-font-cache display)))
       ;; Close the font
       (with-buffer-request (display +x-closefont+)
-	(resource-id id)))))
+	(resource-id id))
+      (deallocate-resource-id display id 'font))))
 
 (defun list-font-names (display pattern &key (max-fonts 65535) (result-type 'list))
   (declare (type display display)

--- a/requests.lisp
+++ b/requests.lisp
@@ -117,8 +117,10 @@
 
 (defun destroy-window (window)
   (declare (type window window))
-  (with-buffer-request ((window-display window) +x-destroywindow+)
-    (window window)))
+  (let ((display (window-display window)))
+    (with-buffer-request (display +x-destroywindow+)
+      (window window))
+    (deallocate-resource-id display (window-id window) 'window)))
 
 (defun destroy-subwindows (window)
   (declare (type window window))


### PR DESCRIPTION
Some resource IDs were not deallocated when the corresponding resources were freed up. 

I did quick greps in the source and compared the results to find them:

1. `grep -PR '[^e]allocate-resource-id' clx/*`
2. `grep -R deallocate-resource-id clx/*`