### PR TITLE
Fix xrender length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/manual/clx.info
+/manual/clx.info-1
+/manual/clx.info-2

--- a/extensions/xrender.lisp
+++ b/extensions/xrender.lisp
@@ -943,7 +943,11 @@ by every function, which attempts to generate RENDER requests."
 				  (* w (picture-format-depth (glyph-set-format glyph-set)))
 				  32)))
              (request-bytes (+ 28
-                               (* h byte-per-line))))
+                               (* h byte-per-line)))
+             (max-bytes-per-request
+              (index* (index- (display-max-request-length display) 6) 4)))
+        (when (> request-bytes max-bytes-per-request)
+          (error "Glyph won't fit in a single request"))
         (with-buffer-request (display (extension-opcode display "RENDER"))
           (data +X-RenderAddGlyphs+)
           (length (ceiling request-bytes 4))

--- a/extensions/xrender.lisp
+++ b/extensions/xrender.lisp
@@ -948,8 +948,8 @@ by every function, which attempts to generate RENDER requests."
           (data +X-RenderAddGlyphs+)
           (length (ceiling request-length 4))
           (glyph-set glyph-set)
-          (card32 1) ;number glyphs
-          (card32 id) ;id
+          (card32 1)                    ;number glyphs
+          (card32 id)                   ;id
           (card16 w)
           (card16 h)
           (int16 x-origin)

--- a/extensions/xrender.lisp
+++ b/extensions/xrender.lisp
@@ -942,11 +942,11 @@ by every function, which attempts to generate RENDER requests."
       (let* ((byte-per-line (* 4 (ceiling 
 				  (* w (picture-format-depth (glyph-set-format glyph-set)))
 				  32)))
-             (request-length (+ 28
-				(* h byte-per-line))))
+             (request-bytes (+ 28
+                               (* h byte-per-line))))
         (with-buffer-request (display (extension-opcode display "RENDER"))
           (data +X-RenderAddGlyphs+)
-          (length (ceiling request-length 4))
+          (length (ceiling request-bytes 4))
           (glyph-set glyph-set)
           (card32 1)                    ;number glyphs
           (card32 id)                   ;id


### PR DESCRIPTION
This fix the problem mentioned in issue #42 .
We signal only the condition, verifying the size from inside `with-buffer-request` is impossible, but I plan to write a macro `with-length-protection` in the future to address the code duplication problem