### PR TITLE
Pruned reference to nonexistent CLtL1 package.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -232,7 +232,6 @@
   (:use common-lisp)
   (:size 3000)
   #+(or kcl ibcl) (:shadow rational)
-  #+allegro (:use cltl1)
   #+allegro (:import-from excl without-interrupts)
   #+excl (:import-from excl arglist)
   #+Genera (:import-from zwei indentation)


### PR DESCRIPTION
Fixes compile error on Allegro.