### PR TITLE
portability: add ecl implementation

### DIFF
--- a/clx.asd
+++ b/clx.asd
@@ -41,7 +41,7 @@ Franz Inc, Berkeley, Ca.
 Independent FOSS developers"
     :maintainer "sharplispers"
     :license "MIT"
-    :depends-on (#+sbcl sb-bsd-sockets)
+    :depends-on (#+(or ecl sbcl) sb-bsd-sockets)
     :version "0.7.2"
     :serial t
     :default-component-class clx-source-file

--- a/package.lisp
+++ b/package.lisp
@@ -238,7 +238,7 @@
   #+lcl3.0 (:import-from lcl arglist)
   #+lispm (:import-from lisp char-bit)
   #+lispm (:import-from sys arglist with-stack-list with-stack-list*)
-  #+sbcl (:use sb-bsd-sockets)
+  #+(or sbcl ecl) (:use sb-bsd-sockets)
   (:export
     *version* access-control access-error access-hosts
     activate-screen-saver add-access-host add-resource add-to-save-set


### PR DESCRIPTION
This is a prerequisite step to remove bundled with ECL implementation.