### PR TITLE
wip: fix: display-keyboard-mapping: don't cache the result

### DIFF
--- a/translate.lisp
+++ b/translate.lisp
@@ -279,8 +279,7 @@
 (defun display-keyboard-mapping (display)
   (declare (type display display))
   (declare (clx-values (simple-array keysym (display-max-keycode keysyms-per-keycode))))
-  (or (display-keysym-mapping display)
-      (setf (display-keysym-mapping display) (keyboard-mapping display))))
+  (setf (display-keysym-mapping display) (keyboard-mapping display)))
 
 (defun keycode->keysym (display keycode keysym-index)
   (declare (type display display)


### PR DESCRIPTION
Keyboard-mapping may change during the runtime, but CLX doesn't pick
that changes. Fixes #53.
