### PR TITLE
Note regarding keyboard mapping cache invalidation

### DIFF
--- a/manual/clx.texinfo
+++ b/manual/clx.texinfo
@@ -11068,6 +11068,12 @@ event-key *event-key-vector*}).
 Type @var{boolean}.
 @end table
 
+Please note that CLX keeps a cache of the keyboard mapping. It is the
+responsibility of the user of CLX to invalidate this cache when
+receiving a @var{:mapping-notify} (@pxref{:mapping-notify}) event from
+the X Server. To help the user with this task CLX provides the function
+@var{mapping-notify} (@pxref{mapping-notify}).
+
 @end defun
 
 


### PR DESCRIPTION
CLX gives the user the responsibility to invalidate the keyboarding
mapping cache and provides them with a function to do so,
mapping-notify.

Related #53