### PR TITLE
manual: Don't cross reference mapping-notify event

### DIFF
--- a/manual/clx.texinfo
+++ b/manual/clx.texinfo
@@ -11070,9 +11070,9 @@ Type @var{boolean}.
 
 Please note that CLX keeps a cache of the keyboard mapping. It is the
 responsibility of the user of CLX to invalidate this cache when
-receiving a @var{:mapping-notify} (@pxref{:mapping-notify}) event from
+receiving a @var{:mapping-notify} event from
 the X Server. To help the user with this task CLX provides the function
-@var{mapping-notify} (@pxref{mapping-notify}).
+@var{mapping-notify}.
 
 @end defun
 


### PR DESCRIPTION
This closes #61. To verify the manual builds run texi2any clx.texinfo on the manual directory