### PR TITLE
Handle incorrect win-gravity.

### DIFF
--- a/manager.lisp
+++ b/manager.lisp
@@ -325,7 +325,14 @@
 		(wm-size-hints-base-height hints) (aref vector 16)))
 	(when (logbitp 9 flags)
 	  (setf (wm-size-hints-win-gravity hints)
-		(decode-type (member-vector +win-gravity-vector+) (aref vector 17)))))
+		;; many games don't initialize win-gravity correctly,
+		;; so we need to bring it to within the correct range
+		;; ICCCM specifies a default gravity of NorthWest
+		(let ((gravity (aref vector 17)))
+		  (decode-type (member-vector +win-gravity-vector+)
+			       (if (< 0 gravity #.(length +win-gravity-vector+))
+				   gravity
+				   #.(position :north-west +win-gravity-vector+)))))))
       ;; Obsolete fields
       (when (or (logbitp 0 flags) (logbitp 2 flags))
 	(setf (wm-size-hints-x hints) (card32->int32 (aref vector 1))


### PR DESCRIPTION
Fixes #67 

Alternatively, instead of `mod`, we could just use some fixed gravity if the value is outside the correct range.