### PR TITLE
why not activate randr extension instead of xinerama (which seems

### DIFF
--- a/clx.asd
+++ b/clx.asd
@@ -79,7 +79,7 @@ Independent FOSS developers"
 	       (:file "dpms")
                (:file "xtest")
                (:file "screensaver")
-               (:file "xinerama")))
+               (:file "randr")))
      (:static-file "NEWS")
      (:static-file "CHANGES")
      (:static-file "README.md")


### PR DESCRIPTION
incomplete).  I'll have a use for it in my window manager.