### PR TITLE
Make extension-event-key-p available at compilation time

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -81,7 +81,8 @@
 ;; Any event-code greater than 34 is for an extension
 (defparameter *first-extension-event-code* 35)
 
-(defvar *extensions* nil) ;; alist of (extension-name-symbol events errors)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defvar *extensions* nil)) ;; alist of (extension-name-symbol events errors)
 
 (defmacro define-extension (name &key events errors)
   ;; Define extension NAME with EVENTS and ERRORS.
@@ -106,10 +107,11 @@
     (declare (clx-values event-key))
     (kintern event)))
 
-(defun extension-event-key-p (key)
-  (dolist (extension *extensions* nil)
-    (when (member key (second extension))
-      (return t))))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun extension-event-key-p (key)
+    (dolist (extension *extensions* nil)
+      (when (member key (second extension))
+        (return t)))))
     
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun allocate-extension-event-code (name)


### PR DESCRIPTION
See #48 for elaborate descripiton. Basically `extension-event-key-p' is used in
`deftype' as part of satisfies so it must be available at compile-time to be a
conforming program.