### PR TITLE
GET-DEFAULT-DISPLAY: Trailing #\: is part of the decnet hostname

### DIFF
--- a/dep-allegro.lisp
+++ b/dep-allegro.lisp
@@ -1208,7 +1208,9 @@ Returns a list of (host display-number screen protocol)."
 	 (slash-i (or (position #\/ name) -1))
 	 (colon-i (position #\: name :start (1+ slash-i)))
 	 (decnet-colon-p (eql (elt name (1+ colon-i)) #\:))
-	 (host (subseq name (1+ slash-i) colon-i))
+	 (host (subseq name (1+ slash-i) (if decnet-colon-p
+                                             (1+ colon-i)
+                                             colon-i)))
 	 (dot-i (and colon-i (position #\. name :start colon-i)))
 	 (display (when colon-i
 		    (parse-integer name

--- a/dep-lispworks.lisp
+++ b/dep-lispworks.lisp
@@ -1014,7 +1014,9 @@ Returns a list of (host display-number screen protocol)."
 	 (slash-i (or (position #\/ name) -1))
 	 (colon-i (position #\: name :start (1+ slash-i)))
 	 (decnet-colon-p (eql (elt name (1+ colon-i)) #\:))
-	 (host (subseq name (1+ slash-i) colon-i))
+	 (host (subseq name (1+ slash-i) (if decnet-colon-p
+                                             (1+ colon-i)
+                                             colon-i)))
 	 (dot-i (and colon-i (position #\. name :start colon-i)))
 	 (display (when colon-i
 		    (parse-integer name

--- a/dep-openmcl.lisp
+++ b/dep-openmcl.lisp
@@ -933,7 +933,9 @@ Returns a list of (host display-number screen protocol)."
 	 (slash-i (or (position #\/ name) -1))
 	 (colon-i (position #\: name :start (1+ slash-i)))
 	 (decnet-colon-p (eql (elt name (1+ colon-i)) #\:))
-	 (host (subseq name (1+ slash-i) colon-i))
+	 (host (subseq name (1+ slash-i) (if decnet-colon-p
+                                             (1+ colon-i)
+                                             colon-i)))
 	 (dot-i (and colon-i (position #\. name :start colon-i)))
 	 (display (when colon-i
 		    (parse-integer name

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -2757,7 +2757,9 @@ Returns a list of (host display-number screen protocol)."
 	 (slash-i (or (position #\/ name) -1))
 	 (colon-i (position #\: name :start (1+ slash-i)))
 	 (decnet-colon-p (eql (elt name (1+ colon-i)) #\:))
-	 (host (subseq name (1+ slash-i) colon-i))
+	 (host (subseq name (1+ slash-i) (if decnet-colon-p
+                                             (1+ colon-i)
+                                             colon-i)))
 	 (dot-i (and colon-i (position #\. name :start colon-i)))
 	 (display (when colon-i
 		    (parse-integer name


### PR DESCRIPTION
Closes #90 

Apropos,

I have a port of XCB's  test suite, but I using Fiasco's API in an 'unorthodox' way so I'm not including it in this PR.

```lisp
(deftest check-parse-display (display-string
                            expected-host
                            expected-display-number
                            expected-screen
                            expected-protocol)
  (multiple-value-bind
        (host display-number screen protocol)
      (parse-display display-string)
    (is (string= host expected-host))
    (is (= display-number expected-display-number))
    (is (= screen expected-screen))
    (is (eq protocol expected-protocol))))

(check-parse-display ":0"   "" 0 0 :local)
(check-parse-display ":1"   "" 1 0 :local)
(check-parse-display ":0.1" "" 0 1 :local)

;; Check hostnames/ip
(check-parse-display "x.org:0"      "x.org"      0 0 :internet)
(check-parse-display "expo:0"       "expo"       0 0 :internet)
(check-parse-display "bigmachine:1" "bigmachine" 1 0 :internet)
(check-parse-display "hydra:0.1"    "hydra"      0 1 :internet)

;; Check ipv4
(check-parse-display
 "198.112.45.11:0"    "198.112.45.11" 0 0 :internet)
(check-parse-display
 "198.112.45.11:0.1"  "198.112.45.11" 0 1 :internet)

;; Check decnet

(check-parse-display "myws::0"   "myws:"  0 0 :decnet)
(check-parse-display "big::1"    "big:"   1 0 :decnet)
(check-parse-display "hydra::0.1" "hydra:" 0 1 :decnet)
```