### PR TITLE
Add support for cmucl

### DIFF
--- a/depdefs.lisp
+++ b/depdefs.lisp
@@ -387,8 +387,6 @@
   ;; FIXME: maybe we should reevaluate this?
   (defvar *def-clx-class-use-defclass*
     #+(or Genera allegro) t
-    ;;#+(and cmu pcl) '(XLIB:DRAWABLE XLIB:WINDOW XLIB:PIXMAP)
-    ;;#+(and cmu (not pcl)) nil
     #-(or Genera allegro) nil
     "Controls whether DEF-CLX-CLASS uses DEFCLASS.
 

--- a/depdefs.lisp
+++ b/depdefs.lisp
@@ -387,9 +387,9 @@
   ;; FIXME: maybe we should reevaluate this?
   (defvar *def-clx-class-use-defclass*
     #+(or Genera allegro) t
-    #+(and cmu pcl) '(XLIB:DRAWABLE XLIB:WINDOW XLIB:PIXMAP)
-    #+(and cmu (not pcl)) nil
-    #-(or Genera cmu allegro) nil
+    ;;#+(and cmu pcl) '(XLIB:DRAWABLE XLIB:WINDOW XLIB:PIXMAP)
+    ;;#+(and cmu (not pcl)) nil
+    #-(or Genera allegro) nil
     "Controls whether DEF-CLX-CLASS uses DEFCLASS.
 
 If it is a list, it is interpreted by DEF-CLX-CLASS to be a list of

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -884,7 +884,7 @@
    :element-type '(unsigned-byte 8)
    :input t :output t :buffering :none))
 
-#+cmucl
+#+cmu
 (defun open-x-stream (host display protocol)
   (let ((stream-fd
          (ecase protocol

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -884,6 +884,47 @@
    :element-type '(unsigned-byte 8)
    :input t :output t :buffering :none))
 
+#+cmucl
+(defun open-x-stream (host display protocol)
+  (let ((stream-fd
+         (ecase protocol
+           ;; establish a TCP connection to the X11 server, which is
+           ;; listening on port 6000 + display-number
+           ((:internet :tcp nil)
+            (let ((fd (ext:connect-to-inet-socket host (+ *x-tcp-port* display))))
+              (unless (plusp fd)
+                (error 'connection-failure
+                       :major-version *protocol-major-version*
+                       :minor-version *protocol-minor-version*
+                       :host host
+                       :display display
+                       :reason (format nil "Cannot connect to internet socket: ~S"
+                                       (unix:get-unix-error-msg))))
+              fd))
+           ;; establish a connection to the X11 server over a Unix
+           ;; socket.  (:|| comes from Darwin's weird DISPLAY
+           ;; environment variable)
+           ((:unix :local :||)
+            (let ((path (unix-socket-path-from-host host display)))
+              (unless (probe-file path)
+                (error 'connection-failure
+                       :major-version *protocol-major-version*
+                       :minor-version *protocol-minor-version*
+                       :host host
+                       :display display
+                       :reason (format nil "Unix socket ~s does not exist" path)))
+              (let ((fd (ext:connect-to-unix-socket (namestring path))))
+                (unless (plusp fd)
+                  (error 'connection-failure
+                         :major-version *protocol-major-version*
+                         :minor-version *protocol-minor-version*
+                         :host host
+                         :display display
+                         :reason (format nil "Can't connect to unix socket: ~S"
+                                         (unix:get-unix-error-msg))))
+                fd))))))
+    (system:make-fd-stream stream-fd :input t :output t :element-type '(unsigned-byte 8))))
+
 ;;; BUFFER-READ-DEFAULT for CMU Common Lisp.
 ;;;
 ;;;    If timeout is 0, then we call LISTEN to see if there is any input.
@@ -1643,7 +1684,7 @@ Returns a list of (host display-number screen protocol)."
 (defmacro with-underlying-simple-vector
     ((variable element-type pixarray) &body body)
   (declare (ignore element-type))
-  `(#+cmu kernel::with-array-data #+sbcl sb-kernel:with-array-data
+  `(#+cmu lisp::with-array-data #+sbcl sb-kernel:with-array-data
           ((,variable ,pixarray) (start) (end))
           (declare (ignore start end))
           ,@body))
@@ -1762,11 +1803,11 @@ Returns a list of (host display-number screen protocol)."
                       height width)
   (declare (type array-index source-width sx sy dest-width dx dy height width))
   #.(declare-buffun)
-  (kernel::with-array-data ((sdata source)
+  (lisp::with-array-data ((sdata source)
                             (sstart)
                             (send))
     (declare (ignore send))
-    (kernel::with-array-data ((ddata dest)
+    (lisp::with-array-data ((ddata dest)
                               (dstart)
                               (dend))
       (declare (ignore dend))


### PR DESCRIPTION
This is a pretty minimal set of changes to get clx to work with cmucl.

Change `*def-clx-class-use-defclass*` to be nil for cmucl.  Not sure
why it was set to use classes for `xlib:drawable`, `xlib:window` and
`xlib:pixmap`.  This is required because dbe wants to include
drawable, which doesn't work when drawable is a class and not a
structure.

Implement `open-x-stream` for cmucl.  This is basically a copy from
the original clx version in cmucl.

Finally, a few minor changes because `with-array-data` is now in the
"LISP" package, not the "KERNEL" package.

With these changes, the demos seem to work.  (The demos want to use
open-clx-display, which isn't defined here.  Not sure what the best
solution is for that.)