### PR TITLE
CLX.TEXINFO: Don't escape > as an HTML entity

### DIFF
--- a/manual/clx.texinfo
+++ b/manual/clx.texinfo
@@ -15162,11 +15162,11 @@ a keycode.
 
 @item
 Convert the keycode into its corresponding keysym, based on the
-current keyboard mapping. See @var{keycode-&gt;keysym}.
+current keyboard mapping. See @var{keycode->keysym}.
 
 @item
 Convert the keysym into the corresponding Common Lisp character. See
-@var{keysym-&gt;character}.
+@var{keysym->character}.
 @end enumerate
 
 @menu


### PR DESCRIPTION
As you can see it is not translated back to > in either the resulting info or the HTML manual.

![image](https://user-images.githubusercontent.com/387111/50049334-3df21f00-00b1-11e9-96a4-9d0e1231151a.png)

https://sharplispers.github.io/clx/Keyboard-Encodings.html#Keyboard-Encodings