### PR TITLE
dependent: improve clx default optimization flags and clx-debugging

### DIFF
--- a/depdefs.lisp
+++ b/depdefs.lisp
@@ -20,6 +20,11 @@
 
 (in-package :xlib)
 
+;;; Enable this for debug optimization settings and to enforce type checks.
+#+ (or)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew :clx-debugging *features*))
+
 ;;;-------------------------------------------------------------------------
 ;;; Declarations
 ;;;-------------------------------------------------------------------------

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -61,9 +61,9 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defconstant +buffer-speed+ #+clx-debugging 1 #-clx-debugging 3
                "Speed compiler option for buffer code.")
-  (defconstant +buffer-safety+ #+clx-debugging 3 #-clx-debugging 0
+  (defconstant +buffer-safety+ #+clx-debugging 3 #-clx-debugging 1
                "Safety compiler option for buffer code.")
-  (defconstant +buffer-debug+ #+clx-debugging 2 #-clx-debugging 1
+  (defconstant +buffer-debug+ #+clx-debugging 3 #-clx-debugging 1
                "Debug compiler option for buffer code>")
   (defun declare-bufmac ()
     `(declare (optimize
@@ -1306,9 +1306,10 @@
 ;;; This controls macro expansion, and isn't changable at run-time You will
 ;;; probably want to set this to nil if you want good performance at
 ;;; production time.
+
 (defconstant +type-check?+
-  #+(or ecl CMU sbcl) nil
-  #-(or ecl CMU sbcl) t)
+  #+clx-debugging t
+  #-clx-debugging nil)
 
 ;; TYPE? is used to allow the code to do error checking at a different level from
 ;; the declarations.  It also does some optimizations for systems that don't have


### PR DESCRIPTION
- clx-debugging as a flag enables/disalbed +type-check?+
- when not debugging safety is set to 1 (instead of 0)

No production system should declare safety to 0 (especially clx which
has a lot of macros which are error-prone). Safety level 0 actually
broke McCLIM's event processing queue on ECL.