### PR TITLE
Revert "Memorize the bit depth for drawable".

### DIFF
--- a/attributes.lisp
+++ b/attributes.lisp
@@ -618,9 +618,8 @@
 (defun drawable-depth (drawable)
   (declare (type drawable drawable))
   (declare (clx-values card8))
-  (or (drawable-bit-depth drawable)
-      (setf (drawable-bit-depth drawable) (with-geometry (drawable :sizes 8)
-                                            (card8-get 1)))))
+  (with-geometry (drawable :sizes 8)
+    (card8-get 1)))
 
 (defun drawable-border-width (drawable)
   ;; setf'able

--- a/clx.lisp
+++ b/clx.lisp
@@ -358,11 +358,8 @@
 (def-clx-class (drawable (:copier nil) (:print-function print-drawable))
   (id 0 :type resource-id)
   (display nil :type (or null display))
-  (plist nil :type list)			; Extension hook
-
-  ;; bit-depth is set by the first call to DRAWABLE-DEPTH, used to avoid repeated
-  ;; round-trips to the server for querying this value. The bit depth of drawables can not change.
-  (bit-depth nil :type (or null fixnum)))
+  ;; Extension hook
+  (plist nil :type list))
 
 (defun print-drawable (drawable stream depth)
   (declare (type drawable drawable)


### PR DESCRIPTION
This commit reverts functional changes in
662e60ce4ad88827441ca6ad04b202cb46e29314.

For context see:
- https://github.com/McCLIM/McCLIM/issues/637
- https://github.com/sharplispers/clx/pull/146
- https://github.com/McCLIM/McCLIM/pull/857

In short: XQuartz X11 server has a very unoptimized code path for
probing the bit depth. Usually this operation is fast, so McCLIM did
check for this bit each time. After finding the issue first fix was
here in clx but that raised a dispute which resulted in this reversal
and caching the depth on McCLIM side.