### PR TITLE
Fix process-event with timeout on SBCL

### DIFF
--- a/buffer.lisp
+++ b/buffer.lisp
@@ -84,12 +84,12 @@
 
 (defun with-buffer-function (buffer timeout function)
   (declare (type display buffer)
-	   (type (or null number) timeout)
-	   (type function function)
-	   (dynamic-extent function)
-	   ;; FIXME: This is probably more a bug in SBCL (logged as
-	   ;; bug #243)
-	   (ignorable timeout))
+           (type (or null real) timeout)
+           (type function function)
+           (dynamic-extent function)
+           ;; FIXME: This is probably more a bug in SBCL (logged as
+           ;; bug #243)
+           (ignorable timeout))
   (with-buffer (buffer :timeout timeout :inline t)
     (funcall function)))
 
@@ -404,7 +404,7 @@
   (declare (type buffer buffer)
 	   (type vector vector)
 	   (type array-index start end)
-	   (type (or null number) timeout))
+	   (type (or null real) timeout))
   (declare (clx-values eof-p))
   (when (buffer-dead buffer)
     (x-error 'closed-display :display buffer))

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -623,21 +623,10 @@
                         &body body)
   ;; This macro is used by WITH-DISPLAY, which claims to be callable
   ;; recursively.  So, had better use a recursive lock.
-  ;;
-  ;; FIXME: This is hideously ugly.  If WITH-TIMEOUT handled NIL
-  ;; timeouts...
   (declare (ignore display whostate))
-  (if timeout
-      `(if ,timeout
-           (handler-case
-               (sb-ext:with-timeout ,timeout
-                 (sb-thread:with-recursive-lock (,lock)
-                   ,@body))
-             (sb-ext:timeout () nil))
-           (sb-thread:with-recursive-lock (,lock)
-             ,@body))
-      `(sb-thread:with-recursive-lock (,lock)
-         ,@body)))
+  `(sb-thread:with-recursive-lock (,lock ,@(when timeout
+                                             `(:timeout ,timeout)))
+     ,@body))
 
 ;;; WITHOUT-ABORTS
 

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -915,7 +915,7 @@
    :input t :output t :buffering :none))
 
 #+clasp
-(defun open-x-stream (host display protocol)  
+(defun open-x-stream (host display protocol)
   (declare (ignore protocol)
            (type (integer 0) display))
   (SB-BSD-SOCKETS:socket-make-stream
@@ -984,7 +984,7 @@
   (declare (type display display)
            (type buffer-bytes vector)
            (type array-index start end)
-           (type (or null fixnum) timeout))
+           (type (or null real) timeout))
   #.(declare-buffun)
   (cond ((and (eql timeout 0)
               (not (listen (display-input-stream display))))
@@ -1001,7 +1001,7 @@
   (declare (type display display)
            (type buffer-bytes vector)
            (type array-index start end)
-           (type (or null fixnum) timeout))
+           (type (or null real) timeout))
   #.(declare-buffun)
   (cond ((and (eql timeout 0)
               (not (listen (display-input-stream display))))


### PR DESCRIPTION
`holding-lock` was implemented using `sb-ext:with-timeout` which can result in asynchronous unwinds and associated problems as discussed in the commit message.