### PR TITLE
Export composite-get-overlay-window, and document it

### DIFF
--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -25,7 +25,6 @@
 	  composite-unredirect-window
 	  composite-unredirect-subwindows
 	  composite-get-overlay-window
-	  
     composite-release-overlay-window))
 
 (define-extension "Composite")
@@ -39,15 +38,16 @@
 
 ;; xrequests
 
-(defconstant  +composite-QueryVersion+			0)
-(defconstant  +composite-RedirectWindow+		1)
-(defconstant  +composite-RedirectSubwindows+		2)
+(defconstant  +composite-QueryVersion+ 0 "Query for the version of composite.")
+(defconstant  +composite-RedirectWindow+ 1 "Store this hierarchy off-screen.")
+(defconstant  +composite-RedirectSubwindows+ 2 )
 (defconstant  +composite-UnredirectWindow+		3)
 (defconstant  +composite-UnredirectSubwindows+		4)
 (defconstant  +composite-CreateRegionFromBorderClip+	5)
-(defconstant  +composite-NameWindowPixmap+		6)
-(defconstant  +composite-GetOverlayWindow+             7)
-(defconstant  +composite-ReleaseOverlayWindow+         8)
+(defconstant  +composite-NameWindowPixmap+ 6
+  "The off-screen pixmap for the window.")
+(defconstant  +composite-GetOverlayWindow+ 7 "Get a surface to draw on.")
+(defconstant  +composite-ReleaseOverlayWindow+ 8 "Release the overlay surface.")
 
 
 (defmacro composite-opcode (display)
@@ -75,7 +75,8 @@
 
 
 (defun composite-redirect-window (window update-type)
-  ""
+  "Store window and its children off-screen, using update-type for whether to
+sync those or not."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window)
@@ -88,7 +89,8 @@
       (card16 0))))
 
 (defun composite-redirect-subwindows (window update-type)
-  ""
+  "Store the subwindows of the window (but not the window itself).
+update-type determines if syncing is allowed."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window)
@@ -101,7 +103,7 @@
       (card16 0))))
 
 (defun composite-unredirect-window (window)
-  ""
+  "Terminates the redirection."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))  
@@ -110,7 +112,7 @@
       (window window))))
 
 (defun composite-unredirect-subwindows (window)
-  ""
+  "Terminates the redirection of the child hierarchies of window."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))  
@@ -119,7 +121,7 @@
       (window window))))
 
 (defun composite-create-region-from-border-clip (window region)
-  ""
+  "Region clipped on surrounding windows."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))
@@ -129,7 +131,7 @@
       (window window))))
 	    
 (defun composite-name-window-pixmap (window drawable)
-  ""
+  "Refer to an off-screen pixmap for the window."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))
@@ -139,7 +141,8 @@
       (drawable drawable))))
 
 (defun composite-get-overlay-window (window)
-  ""
+  "Take control of the window for composite use. A place to draw things without
+interference. Release with COMPOSITE-RELEASE-OVERLAY-WINDOW."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))
@@ -151,7 +154,7 @@
        (card32-get 8)))))
 
 (defun composite-release-overlay-window (window)
-  ""
+  "Release a window which was controlled by COMPOSITE-GET-OVERLAY-WINDOW."
   (let ((display (window-display window)))
     (declare (type display display)
              (type window window))

--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -29,21 +29,26 @@
 
 (define-extension "Composite")
 
-(defconstant +composite-major+    0)
-(defconstant +composite-minor+    4)
+(defconstant +composite-major+ 0 "Major version.")
+(defconstant +composite-minor+ 4 "Minor version.")
 
 
-(defconstant +redirect-automatic+		0)
-(defconstant +redirect-manual+			1)
+(defconstant +redirect-automatic+ 0
+  "The automatic update type automatically updates the parent window.")
+(defconstant +redirect-manual+ 1
+  "Prevents some activities that would otherwise be automatic.")
 
 ;; xrequests
 
 (defconstant  +composite-QueryVersion+ 0 "Query for the version of composite.")
 (defconstant  +composite-RedirectWindow+ 1 "Store this hierarchy off-screen.")
-(defconstant  +composite-RedirectSubwindows+ 2 )
-(defconstant  +composite-UnredirectWindow+		3)
-(defconstant  +composite-UnredirectSubwindows+		4)
-(defconstant  +composite-CreateRegionFromBorderClip+	5)
+(defconstant  +composite-RedirectSubwindows+ 2 "Store only the sub-hierarchy.")
+(defconstant  +composite-UnredirectWindow+ 3
+  "Stop storing the window and subwindows.")
+(defconstant  +composite-UnredirectSubwindows+ 4
+  "Stop storing the sub-hierarchy.")
+(defconstant  +composite-CreateRegionFromBorderClip+ 5
+  "The region clinpped against the surrounding windows.")
 (defconstant  +composite-NameWindowPixmap+ 6
   "The off-screen pixmap for the window.")
 (defconstant  +composite-GetOverlayWindow+ 7 "Get a surface to draw on.")
@@ -62,7 +67,7 @@
 ;; x requests
 
 (defun composite-query-version (display)
-  ""
+  "Query for the version. All clients are expected to query!"
   (declare (type display display))
   (with-buffer-request-and-reply (display (composite-opcode display) nil :sizes (32))
 				 ((data +composite-QueryVersion+)
@@ -142,7 +147,8 @@ update-type determines if syncing is allowed."
 
 (defun composite-get-overlay-window (window)
   "Take control of the window for composite use. A place to draw things without
-interference. Release with COMPOSITE-RELEASE-OVERLAY-WINDOW."
+interference. Requires a compositing window manager to be running in order to
+use the overlay. Release it with COMPOSITE-RELEASE-OVERLAY-WINDOW."
   (let ((display (window-display window)))
     (declare (type display display)
 	     (type window window))

--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -20,12 +20,12 @@
 (in-package :xlib)
 
 (export '(composite-query-version
-	  composite-redirect-window
-	  composite-redirect-subwindows
-	  composite-unredirect-window
-	  composite-unredirect-subwindows
-	  composite-get-overlay-window
-    composite-release-overlay-window))
+          composite-redirect-window
+          composite-redirect-subwindows
+          composite-unredirect-window
+          composite-unredirect-subwindows
+          composite-get-overlay-window
+          composite-release-overlay-window))
 
 (define-extension "Composite")
 
@@ -70,9 +70,9 @@
   "Query for the version. All clients are expected to query!"
   (declare (type display display))
   (with-buffer-request-and-reply (display (composite-opcode display) nil :sizes (32))
-				 ((data +composite-QueryVersion+)
-				  (card32 +composite-major+)
-				  (card32 +composite-minor+))
+                                 ((data +composite-QueryVersion+)
+                                  (card32 +composite-major+)
+                                  (card32 +composite-minor+))
     (values
      (card32-get 8)
      (card32-get 12))))
@@ -84,8 +84,8 @@
 sync those or not."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window)
-	     (type update-type update-type))  
+             (type window window)
+             (type update-type update-type))
     (with-buffer-request (display (composite-opcode display))
       (data +composite-redirectwindow+)
       (window window)
@@ -98,8 +98,8 @@ sync those or not."
 update-type determines if syncing is allowed."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window)
-	     (type update-type update-type))  
+             (type window window)
+             (type update-type update-type))
     (with-buffer-request (display (composite-opcode display))
       (data +composite-redirectsubwindows+)
       (window window)
@@ -111,7 +111,7 @@ update-type determines if syncing is allowed."
   "Terminates the redirection."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window))  
+             (type window window))
     (with-buffer-request (display (composite-opcode display))
       (data +composite-unredirectwindow+)
       (window window))))
@@ -120,7 +120,7 @@ update-type determines if syncing is allowed."
   "Terminates the redirection of the child hierarchies of window."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window))  
+             (type window window))
     (with-buffer-request (display (composite-opcode display))
       (data +composite-unredirectsubwindows+)
       (window window))))
@@ -129,17 +129,17 @@ update-type determines if syncing is allowed."
   "Region clipped on surrounding windows."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window))
-    (with-buffer-request (display (composite-opcode display)) 
+             (type window window))
+    (with-buffer-request (display (composite-opcode display))
       (data +composite-createregionfromborderclip+)
       (card32 region)
       (window window))))
-	    
+
 (defun composite-name-window-pixmap (window drawable)
   "Refer to an off-screen pixmap for the window."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window))
+             (type window window))
     (with-buffer-request (display (composite-opcode display))
       (data +composite-namewindowpixmap+)
       (window window)
@@ -151,13 +151,11 @@ interference. Requires a compositing window manager to be running in order to
 use the overlay. Release it with COMPOSITE-RELEASE-OVERLAY-WINDOW."
   (let ((display (window-display window)))
     (declare (type display display)
-	     (type window window))
+             (type window window))
     (with-buffer-request-and-reply (display (composite-opcode display) nil :sizes (32))
-				   ((data +composite-getoverlaywindow+)
-				    (window window)
-				    )
-      (values
-       (card32-get 8)))))
+                                   ((data +composite-getoverlaywindow+)
+                                    (window window))
+      (values (card32-get 8)))))
 
 (defun composite-release-overlay-window (window)
   "Release a window which was controlled by COMPOSITE-GET-OVERLAY-WINDOW."

--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -26,7 +26,8 @@
 	  composite-unredirect-subwindows
 	  composite-get-overlay-window
 	  
-	  ))
+    composite-release-overlay-window))
+
 (define-extension "Composite")
 
 (defconstant +composite-major+    0)

--- a/extensions/composite.lisp
+++ b/extensions/composite.lisp
@@ -29,8 +29,10 @@
 
 (define-extension "Composite")
 
-(defconstant +composite-major+ 0 "Major version.")
-(defconstant +composite-minor+ 4 "Minor version.")
+(defconstant +composite-major+ 0
+  "Major version.")
+(defconstant +composite-minor+ 4
+  "Minor version.")
 
 
 (defconstant +redirect-automatic+ 0
@@ -40,9 +42,12 @@
 
 ;; xrequests
 
-(defconstant  +composite-QueryVersion+ 0 "Query for the version of composite.")
-(defconstant  +composite-RedirectWindow+ 1 "Store this hierarchy off-screen.")
-(defconstant  +composite-RedirectSubwindows+ 2 "Store only the sub-hierarchy.")
+(defconstant  +composite-QueryVersion+ 0
+  "Query for the version of composite.")
+(defconstant  +composite-RedirectWindow+ 1
+  "Store this hierarchy off-screen.")
+(defconstant  +composite-RedirectSubwindows+ 2
+  "Store only the sub-hierarchy.")
 (defconstant  +composite-UnredirectWindow+ 3
   "Stop storing the window and subwindows.")
 (defconstant  +composite-UnredirectSubwindows+ 4
@@ -51,8 +56,10 @@
   "The region clinpped against the surrounding windows.")
 (defconstant  +composite-NameWindowPixmap+ 6
   "The off-screen pixmap for the window.")
-(defconstant  +composite-GetOverlayWindow+ 7 "Get a surface to draw on.")
-(defconstant  +composite-ReleaseOverlayWindow+ 8 "Release the overlay surface.")
+(defconstant  +composite-GetOverlayWindow+ 7
+  "Get a surface to draw on.")
+(defconstant  +composite-ReleaseOverlayWindow+ 8
+  "Release the overlay surface.")
 
 
 (defmacro composite-opcode (display)
@@ -61,8 +68,6 @@
 ;; types
 
 (deftype update-type () '(card8))
-
-
 
 ;; x requests
 
@@ -76,8 +81,6 @@
     (values
      (card32-get 8)
      (card32-get 12))))
-
-
 
 (defun composite-redirect-window (window update-type)
   "Store window and its children off-screen, using update-type for whether to


### PR DESCRIPTION
Exported this (since it is needed anyway for the other exported symbol `composite-release-overlay-window`). 

Added some documentation strings to these.