### PR TITLE
clx.texinfo: Update Dead Link

### DIFF
--- a/manual/clx.texinfo
+++ b/manual/clx.texinfo
@@ -16022,7 +16022,7 @@ server and rendering sets of them.
 @subsection Picture formats
 
 The following is what the X protocol rendering spec has to say about picture formats.
-@url{http://www.xfree86.org/~keithp/render/protocol.html}
+@url{https://www.x.org/releases/X11R7.7/doc/renderproto/renderproto.txt}
 
 
 The @var{picture-format} object holds information needed to translate pixel values


### PR DESCRIPTION
Title says it all. Just in case someone wants to check the new link points to the same document you can check against the most recent version in the wayback machine: https://web.archive.org/web/20030202005919/http://www.xfree86.org/~keithp/render/protocol.html