### PR TITLE
Fix conditional store

### DIFF
--- a/dependent.lisp
+++ b/dependent.lisp
@@ -593,14 +593,6 @@
   `(mp:with-lock-held (,lock ,whostate ,@(and timeout `(:timeout ,timeout)))
      ,@body))
 
-#+clisp
-(defmacro holding-lock ((lock display &optional (whostate "CLX wait")
-                              &key timeout)
-                        &body body)
-  (declare (ignore lock display whostate timeout))
-  `(progn
-     ,@body))
-
 #+(and ecl threads)
 (defmacro holding-lock ((lock display &optional (whostate "CLX wait")
                               &key timeout)

--- a/dependent.lisp
+++ b/dependent.lisp
@@ -803,25 +803,34 @@
 ;; This should use GET-SETF-METHOD to avoid evaluating subforms multiple times.
 ;; It doesn't because CLtL doesn't pass the environment to GET-SETF-METHOD.
 
-;; FIXME: both sbcl and ecl has compare-and-swap these days.
-;; FIXME: Verify for clasp 
-
-#-sbcl
-(defmacro conditional-store (place old-value new-value)
-  `(without-interrupts
-     (cond ((eq ,place ,old-value)
-            (setf ,place ,new-value)
-            t))))
-
-#+sbcl
+#-(or (and clasp threads) ecl sbcl)
 (progn
   (defvar *conditional-store-lock*
-    (sb-thread:make-mutex :name "conditional store"))
+    (make-process-lock "conditional store"))
   (defmacro conditional-store (place old-value new-value)
-    `(sb-thread:with-mutex (*conditional-store-lock*)
-       (cond ((eq ,place ,old-value)
-              (setf ,place ,new-value)
-              t)))))
+    `(holding-lock (*conditional-store-lock*)
+       (if (eq ,place ,old-value)
+           (prog1 t
+             (setf ,place ,new-value))
+           nil))))
+
+#+(and clasp threads)
+(defmacro conditional-store (place old-value new-value)
+  (let ((ov (gensym)))
+    `(let ((,ov ,old-value))
+       (eq ,ov (mp:cas ,place ,ov ,new-value)))))
+
+#+ecl
+(defmacro conditional-store (place old-value new-value)
+  (let ((ov (gensym)))
+    `(let ((,ov ,old-value))
+       (eq ,ov (mp:compare-and-swap ,place ,ov ,new-value)))))
+
+#+sbcl
+(defmacro conditional-store (place old-value new-value)
+  (let ((ov (gensym)))
+    `(let ((,ov ,old-value))
+       (eq ,ov (sb-ext:compare-and-swap ,place ,ov ,new-value)))))
 
 ;;;----------------------------------------------------------------------------
 ;;; IO Error Recovery


### PR DESCRIPTION
Wrapping a body in without-interrupts is useless when multiprocessing. Casual use of CLX with implementations other than SBCL (which used a lock) proved to exercise a race condition where the operation threaded-nconc looped over the buffer forever, because circular list was created.

Also we use CAS operation on implementations which implement it.