### PR TITLE
Support XAUTHLOCALHOSTNAME environment variable

### DIFF
--- a/display.lisp
+++ b/display.lisp
@@ -36,8 +36,10 @@
 ;;; The format of the .Xauthority file is documented in the XFree
 ;;; sources, in the file xc/lib/Xau/README.
 
-;;; Stolen from the cmucl sources, with patches by Hannu Rummukainen and
-;;; Scott Fahlman.
+;;; Stolen from the cmucl sources, with patches by
+;;; * Hannu Rummukainen
+;;; * Scott Fahlman
+;;; * Copyright (C) 2022 Massimo Zaniboni <mzan@dokmelody.org>
 
 (defun read-xauth-entry (stream)
   (labels ((read-short (stream &optional (eof-errorp t))
@@ -108,7 +110,7 @@
 	    (when (or (eql protocol :local)
 		      (and (eql protocol :internet)
 			   (equal host-address '(127 0 0 1))))
-	      (setq host-address (get-host-name))
+	      (setq host-address (or (getenv "XAUTHLOCALHOSTNAME") (get-host-name)))
 	      (setq protocol :local))
 	    (loop
 	     (destructuring-bind (family address number name data)


### PR DESCRIPTION
Hi, in OpenSUSE Leap using ``Distrobox`` (a tool similar to ``Toolbox`` of Fedora), CLX cannot connect to the X server, because the XAUTHORITY file still uses the original "dok" host name, but under ``Distrobox`` the host is renamed to something like "dok.dev", where "dev" is the name of the ``Distrobox`` container.

If I use the content of  XAUTHLOCALHOSTNAME, (when present), it is all ok.

```
$> env | ag X
XDG_CONFIG_DIRS=/home/zanibonim/.config/kdedefaults:/etc/xdg
XDG_SESSION_PATH=/org/freedesktop/DisplayManager/Session1
DISTROBOX_ENTER_PATH=/usr/bin/distrobox-enter
XCURSOR_SIZE=24
XDG_SEAT=seat0
XDG_SESSION_DESKTOP=KDE
XDG_SESSION_TYPE=x11
XAUTHORITY=/run/user/1000/xauth_FMoQkx
XDG_CURRENT_DESKTOP=KDE
XDG_SEAT_PATH=/org/freedesktop/DisplayManager/Seat0
XSESSION_IS_UP=yes
XDG_SESSION_CLASS=user
XAUTHLOCALHOSTNAME=dok
XDG_VTNR=7
XDG_SESSION_ID=3
XDG_RUNTIME_DIR=/run/user/1000
XCURSOR_THEME=breeze_cursors
XDG_DATA_DIRS=/home/zanibonim/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share

$> env | ag host
HOSTNAME=dev.dok
HOST=dev.dok
XAUTHLOCALHOSTNAME=dok
HOSTTYPE=x86_64
zanibonim@dev:~> 
```
