### PR TITLE
Enable CLX for LispWorks 8.x and later (confirmed by McCLIM)

### DIFF
--- a/dep-lispworks.lisp
+++ b/dep-lispworks.lisp
@@ -20,7 +20,11 @@
 
 (in-package :xlib)
 
-#-(or lispworks6 lispworks7)
+;;; NOTE: This was: #-(or lispworks6 lispworks7), i.e. LW 5.x and 6.x only.
+;;;       Now LW 8.x is confirmed working (by running McCLIM), thus we should
+;;;       enable LW 8.x and all future versions by default, and only very old
+;;;       LW versions (4.x and 5.x) are disabled here.  -- binghe, 2023/12/29
+#+(or lispworks4 lispworks5)
 (error "Sorry, your ~S lisp version ~S is not currently supported.  ~
         Patches are welcome."
        (lisp-implementation-type) (lisp-implementation-version))


### PR DESCRIPTION
Hi,

Recently McCLIM has been greatly improved. I just tried loading McCLIM in LispWorks 8.0.1 (on macOS) and it seems that the only blocking issue is CLX, which has disabled the support of LispWorks versions 8.x and later:
```
#-(or lispworks6 lispworks7)
(error "Sorry, your ~S lisp version ~S is not currently supported.  ~
        Patches are welcome."
       (lisp-implementation-type) (lisp-implementation-version))
```
But actually the code runs very well under LispWorks 8.0.1, and by disabling the above code I can indeed run McCLIM in LispWorks:
<img width="695" alt="Schermata 2023-12-29 alle 19 21 50" src="https://github.com/sharplispers/clx/assets/163421/df0881b0-d52b-4186-830c-9eeb58ba3fe9">

Therefore I propose this trivial patch which enables all LispWorks versions 6.x and later.

NOTE: The existing CLX code doesn't support connecting to X11 (Xquartz) server listening on unix domain sockets, on macOS. As a workaround, I had to SSH to `localhost` with X11 forwarding enabled (`-X`) and then run the X11-based LispWorks console image and got the above screenshot.  I will take a look at CLX code and see if the support of unix domain sockets can be added (no estimates on time).

--Chun